### PR TITLE
Everywhere: Replace SERENITY_SOURCE_DIR with LADYBIRD_SOURCE_DIR

### DIFF
--- a/.github/workflows/lagom-template.yml
+++ b/.github/workflows/lagom-template.yml
@@ -20,7 +20,7 @@ on:
 env:
   # runner.workspace = /home/runner/work/serenity
   # github.workspace = /home/runner/work/serenity/serenity
-  SERENITY_SOURCE_DIR: ${{ github.workspace }}
+  LADYBIRD_SOURCE_DIR: ${{ github.workspace }}
   CCACHE_DIR: ${{ github.workspace }}/.ccache
 
 jobs:

--- a/.github/workflows/libjs-test262.yml
+++ b/.github/workflows/libjs-test262.yml
@@ -3,7 +3,7 @@ name: Run test262 and test-wasm
 on: [push]
 
 env:
-  SERENITY_SOURCE_DIR: ${{ github.workspace }}
+  LADYBIRD_SOURCE_DIR: ${{ github.workspace }}
 
 jobs:
   run_and_update_results:
@@ -92,7 +92,7 @@ jobs:
               -DCMAKE_CXX_COMPILER=g++-13 \
               -DWASM_SPEC_TEST_SKIP_FORMATTING=ON \
               -DINCLUDE_WASM_SPEC_TESTS=ON \
-              -DSERENITY_SOURCE_DIR=${{ env.SERENITY_SOURCE_DIR }} \
+              -DLADYBIRD_SOURCE_DIR=${{ env.LADYBIRD_SOURCE_DIR }} \
               -DSERENITY_CACHE_DIR=Build/caches
           ninja -C Build test262-runner test-js test-wasm
 

--- a/.github/workflows/nightly-android.yml
+++ b/.github/workflows/nightly-android.yml
@@ -8,7 +8,7 @@ on:
 env:
   # runner.workspace = /home/runner/work/serenity
   # github.workspace = /home/runner/work/serenity/serenity
-  SERENITY_SOURCE_DIR: ${{ github.workspace }}
+  LADYBIRD_SOURCE_DIR: ${{ github.workspace }}
   CCACHE_DIR: ${{ github.workspace }}/.ccache
 
 concurrency:

--- a/.github/workflows/serenity-js-artifacts.yml
+++ b/.github/workflows/serenity-js-artifacts.yml
@@ -3,7 +3,7 @@ name: Package the js repl as a binary artifact
 on: [push]
 
 env:
-  SERENITY_SOURCE_DIR: ${{ github.workspace }}
+  LADYBIRD_SOURCE_DIR: ${{ github.workspace }}
   SERENITY_CCACHE_DIR: ${{ github.workspace }}/.ccache
 
 jobs:

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -2,7 +2,7 @@ name: Build Wasm Modules
 on: [ push, pull_request ]
 
 env:
-  SERENITY_SOURCE_DIR: ${{ github.workspace }}
+  LADYBIRD_SOURCE_DIR: ${{ github.workspace }}
   SERENITY_CCACHE_DIR: ${{ github.workspace }}/.ccache
 
 concurrency: wasm

--- a/Documentation/RunningTests.md
+++ b/Documentation/RunningTests.md
@@ -21,12 +21,12 @@ For a Lagom-only build, pass the Lagom directory to CMake. The `BUILD_LAGOM` CMa
 cmake -GNinja -S Meta/Lagom -B Build/lagom -DBUILD_LAGOM=ON
 ```
 
-In both cases, the tests can be run via ninja after doing a build. Note that `test-js` requires the `SERENITY_SOURCE_DIR` environment variable to be set
+In both cases, the tests can be run via ninja after doing a build. Note that `test-js` requires the `LADYBIRD_SOURCE_DIR` environment variable to be set
 to the root of the serenity source tree when running on a non-SerenityOS host.
 
 ```sh
 # /path/to/serenity repository
-export SERENITY_SOURCE_DIR=${PWD}
+export LADYBIRD_SOURCE_DIR=${PWD}
 cd Build/lagom
 ninja
 ninja test
@@ -55,13 +55,13 @@ The sanitizers can be enabled with the `-DENABLE_FOO_SANITIZER` set of flags. Fo
 cmake -GNinja -S Meta/Lagom -B Build/lagom -DBUILD_LAGOM=ON -DENABLE_ADDRESS_SANITIZER=ON -DENABLE_UNDEFINED_SANITIZER=ON
 cd Build/lagom
 ninja
-CTEST_OUTPUT_ON_FAILURE=1 SERENITY_SOURCE_DIR=${PWD}/../.. ninja test
+CTEST_OUTPUT_ON_FAILURE=1 LADYBIRD_SOURCE_DIR=${PWD}/../.. ninja test
 ```
 
 To ensure that Undefined Sanitizer errors fail the test, the `halt_on_error` flag should be set to 1 in the environment variable `UBSAN_OPTIONS`.
 
 ```sh
-UBSAN_OPTIONS=halt_on_error=1 CTEST_OUTPUT_ON_FAILURE=1 SERENITY_SOURCE_DIR=${PWD}/.. ninja test
+UBSAN_OPTIONS=halt_on_error=1 CTEST_OUTPUT_ON_FAILURE=1 LADYBIRD_SOURCE_DIR=${PWD}/.. ninja test
 ```
 
 ## Running Target Tests

--- a/Ladybird/CMakeLists.txt
+++ b/Ladybird/CMakeLists.txt
@@ -62,17 +62,17 @@ endif()
 
 if (PROJECT_IS_TOP_LEVEL)
     get_filename_component(
-        SERENITY_SOURCE_DIR "${ladybird_SOURCE_DIR}/.."
+        LADYBIRD_SOURCE_DIR "${ladybird_SOURCE_DIR}/.."
         ABSOLUTE
     )
-    list(APPEND CMAKE_MODULE_PATH "${SERENITY_SOURCE_DIR}/Meta/CMake")
+    list(APPEND CMAKE_MODULE_PATH "${LADYBIRD_SOURCE_DIR}/Meta/CMake")
     include(cmake/EnableLagom.cmake)
     include(use_linker)
     include(lagom_compile_options)
     include(lagom_install_options)
 else()
-    # FIXME: Use SERENITY_SOURCE_DIR in Lagom/CMakeLists.txt
-    set(SERENITY_SOURCE_DIR "${SERENITY_PROJECT_ROOT}")
+    # FIXME: Use LADYBIRD_SOURCE_DIR in Lagom/CMakeLists.txt
+    set(LADYBIRD_SOURCE_DIR "${SERENITY_PROJECT_ROOT}")
 endif()
 
 add_compile_options(-DAK_DONT_REPLACE_STD)
@@ -181,14 +181,14 @@ if (APPLE)
 endif()
 
 target_sources(ladybird PUBLIC FILE_SET ladybird TYPE HEADERS
-    BASE_DIRS ${SERENITY_SOURCE_DIR}
+    BASE_DIRS ${LADYBIRD_SOURCE_DIR}
     FILES ${LADYBIRD_HEADERS}
 )
 target_link_libraries(ladybird PRIVATE AK LibCore LibFileSystem LibGfx LibImageDecoderClient LibIPC LibJS LibMain LibSQL LibWeb LibWebView LibProtocol LibURL)
 
 target_include_directories(ladybird PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-target_include_directories(ladybird PRIVATE ${SERENITY_SOURCE_DIR}/Userland/)
-target_include_directories(ladybird PRIVATE ${SERENITY_SOURCE_DIR}/Userland/Services/)
+target_include_directories(ladybird PRIVATE ${LADYBIRD_SOURCE_DIR}/Userland/)
+target_include_directories(ladybird PRIVATE ${LADYBIRD_SOURCE_DIR}/Userland/Services/)
 
 function(set_helper_process_properties)
     set(targets ${ARGV})
@@ -206,12 +206,12 @@ function(set_helper_process_properties)
 endfunction()
 
 add_executable(headless-browser
-    ${SERENITY_SOURCE_DIR}/Userland/Utilities/headless-browser.cpp
+    ${LADYBIRD_SOURCE_DIR}/Userland/Utilities/headless-browser.cpp
     HelperProcess.cpp
     Utilities.cpp)
 
 target_include_directories(headless-browser PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-target_include_directories(headless-browser PRIVATE ${SERENITY_SOURCE_DIR}/Userland/)
+target_include_directories(headless-browser PRIVATE ${LADYBIRD_SOURCE_DIR}/Userland/)
 target_link_libraries(headless-browser PRIVATE AK LibCore LibWeb LibWebView LibWebSocket LibCrypto LibFileSystem LibGemini LibHTTP LibImageDecoderClient LibJS LibGfx LibMain LibSQL LibTLS LibIPC LibDiff LibProtocol LibURL)
 
 if (ANDROID)
@@ -219,13 +219,13 @@ if (ANDROID)
 endif()
 
 add_custom_target(run${LADYBIRD_CUSTOM_TARGET_SUFFIX}
-    COMMAND "${CMAKE_COMMAND}" -E env "SERENITY_SOURCE_DIR=${SERENITY_SOURCE_DIR}" "$<TARGET_FILE:ladybird>" $ENV{LAGOM_ARGS}
+    COMMAND "${CMAKE_COMMAND}" -E env "LADYBIRD_SOURCE_DIR=${LADYBIRD_SOURCE_DIR}" "$<TARGET_FILE:ladybird>" $ENV{LAGOM_ARGS}
     USES_TERMINAL
     VERBATIM
 )
 
 add_custom_target(debug${LADYBIRD_CUSTOM_TARGET_SUFFIX}
-    COMMAND "${CMAKE_COMMAND}" -E env "SERENITY_SOURCE_DIR=${SERENITY_SOURCE_DIR}" gdb -ex "set follow-fork-mode child" "$<TARGET_FILE:ladybird>"
+    COMMAND "${CMAKE_COMMAND}" -E env "LADYBIRD_SOURCE_DIR=${LADYBIRD_SOURCE_DIR}" gdb -ex "set follow-fork-mode child" "$<TARGET_FILE:ladybird>"
     USES_TERMINAL
 )
 
@@ -248,7 +248,7 @@ function(create_ladybird_bundle target_name)
         MACOSX_BUNDLE_GUI_IDENTIFIER org.SerenityOS.Ladybird
         MACOSX_BUNDLE_BUNDLE_VERSION ${PROJECT_VERSION}
         MACOSX_BUNDLE_SHORT_VERSION_STRING ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
-        MACOSX_BUNDLE_INFO_PLIST "${SERENITY_SOURCE_DIR}/Ladybird/Info.plist"
+        MACOSX_BUNDLE_INFO_PLIST "${LADYBIRD_SOURCE_DIR}/Ladybird/Info.plist"
         MACOSX_BUNDLE TRUE
         WIN32_EXECUTABLE TRUE
         XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER org.SerenityOS.Ladybird
@@ -258,7 +258,7 @@ function(create_ladybird_bundle target_name)
         set(bundle_dir "$<TARGET_BUNDLE_DIR:${target_name}>")
         add_custom_command(TARGET ${target_name} POST_BUILD
             COMMAND "${CMAKE_COMMAND}" -E make_directory "${bundle_dir}/Contents/Resources"
-            COMMAND "iconutil" --convert icns "${SERENITY_SOURCE_DIR}/Ladybird/Icons/macos/app_icon.iconset" --output "${bundle_dir}/Contents/Resources/app_icon.icns"
+            COMMAND "iconutil" --convert icns "${LADYBIRD_SOURCE_DIR}/Ladybird/Icons/macos/app_icon.iconset" --output "${bundle_dir}/Contents/Resources/app_icon.icns"
         )
     endif()
 endfunction()
@@ -284,7 +284,7 @@ include(CTest)
 if (BUILD_TESTING)
     add_test(
         NAME LibWeb
-        COMMAND $<TARGET_FILE:headless-browser> --resources "${resource_base_dir}" --run-tests ${SERENITY_SOURCE_DIR}/Tests/LibWeb --dump-failed-ref-tests
+        COMMAND $<TARGET_FILE:headless-browser> --resources "${resource_base_dir}" --run-tests ${LADYBIRD_SOURCE_DIR}/Tests/LibWeb --dump-failed-ref-tests
     )
     add_test(
         NAME WPT
@@ -294,6 +294,6 @@ if (BUILD_TESTING)
     set_tests_properties(LibWeb WPT PROPERTIES
         DEPENDS ladybird
         ENVIRONMENT QT_QPA_PLATFORM=offscreen
-        ENVIRONMENT "SERENITY_SOURCE_DIR=${SERENITY_SOURCE_DIR}"
+        ENVIRONMENT "LADYBIRD_SOURCE_DIR=${LADYBIRD_SOURCE_DIR}"
     )
 endif()

--- a/Ladybird/ImageDecoder/CMakeLists.txt
+++ b/Ladybird/ImageDecoder/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(IMAGE_DECODER_SOURCE_DIR ${SERENITY_SOURCE_DIR}/Userland/Services/ImageDecoder)
+set(IMAGE_DECODER_SOURCE_DIR ${LADYBIRD_SOURCE_DIR}/Userland/Services/ImageDecoder)
 
 set(CMAKE_AUTOMOC OFF)
 set(CMAKE_AUTORCC OFF)
@@ -22,6 +22,6 @@ endif()
 add_executable(ImageDecoder main.cpp)
 target_link_libraries(ImageDecoder PRIVATE imagedecoder LibCore LibMain)
 
-target_include_directories(imagedecoder PRIVATE ${SERENITY_SOURCE_DIR}/Userland/Services/)
+target_include_directories(imagedecoder PRIVATE ${LADYBIRD_SOURCE_DIR}/Userland/Services/)
 target_include_directories(imagedecoder PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/..)
 target_link_libraries(imagedecoder PRIVATE LibCore LibGfx LibIPC LibImageDecoderClient LibMain LibThreading)

--- a/Ladybird/RequestServer/CMakeLists.txt
+++ b/Ladybird/RequestServer/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(REQUESTSERVER_SOURCE_DIR ${SERENITY_SOURCE_DIR}/Userland/Services/RequestServer)
+set(REQUESTSERVER_SOURCE_DIR ${LADYBIRD_SOURCE_DIR}/Userland/Services/RequestServer)
 
 set(CMAKE_AUTOMOC OFF)
 set(CMAKE_AUTORCC OFF)
@@ -31,7 +31,7 @@ endif()
 add_executable(RequestServer main.cpp)
 target_link_libraries(RequestServer PRIVATE requestserver)
 
-target_include_directories(requestserver PRIVATE ${SERENITY_SOURCE_DIR}/Userland/Services/)
+target_include_directories(requestserver PRIVATE ${LADYBIRD_SOURCE_DIR}/Userland/Services/)
 target_include_directories(requestserver PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/..)
 target_link_libraries(requestserver PUBLIC LibCore LibMain LibCrypto LibFileSystem LibGemini LibHTTP LibIPC LibMain LibTLS LibWebView LibWebSocket LibURL LibThreading)
 if (${CMAKE_SYSTEM_NAME} MATCHES "SunOS")

--- a/Ladybird/SQLServer/CMakeLists.txt
+++ b/Ladybird/SQLServer/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(SQL_SERVER_SOURCE_DIR ${SERENITY_SOURCE_DIR}/Userland/Services/SQLServer)
+set(SQL_SERVER_SOURCE_DIR ${LADYBIRD_SOURCE_DIR}/Userland/Services/SQLServer)
 
 set(SQL_SERVER_SOURCES
     ${SQL_SERVER_SOURCE_DIR}/ConnectionFromClient.cpp
@@ -9,6 +9,6 @@ set(SQL_SERVER_SOURCES
 
 add_executable(SQLServer ${SQL_SERVER_SOURCES})
 
-target_include_directories(SQLServer PRIVATE ${SERENITY_SOURCE_DIR}/Userland/Services/)
+target_include_directories(SQLServer PRIVATE ${LADYBIRD_SOURCE_DIR}/Userland/Services/)
 target_include_directories(SQLServer PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/..)
 target_link_libraries(SQLServer PRIVATE LibCore LibFileSystem LibIPC LibSQL LibMain)

--- a/Ladybird/WebContent/CMakeLists.txt
+++ b/Ladybird/WebContent/CMakeLists.txt
@@ -1,5 +1,5 @@
 include(accelerated_graphics)
-set(WEBCONTENT_SOURCE_DIR ${SERENITY_SOURCE_DIR}/Userland/Services/WebContent/)
+set(WEBCONTENT_SOURCE_DIR ${LADYBIRD_SOURCE_DIR}/Userland/Services/WebContent/)
 
 set(WEBCONTENT_SOURCES
     ${WEBCONTENT_SOURCE_DIR}/ConnectionFromClient.cpp
@@ -45,17 +45,17 @@ else()
         set(LIB_TYPE SHARED)
     endif()
     add_library(webcontent ${LIB_TYPE} ${WEBCONTENT_SOURCES})
-    target_include_directories(webcontent PRIVATE ${SERENITY_SOURCE_DIR}/Userland/Services/)
-    target_include_directories(webcontent PRIVATE ${SERENITY_SOURCE_DIR}/Userland/)
+    target_include_directories(webcontent PRIVATE ${LADYBIRD_SOURCE_DIR}/Userland/Services/)
+    target_include_directories(webcontent PRIVATE ${LADYBIRD_SOURCE_DIR}/Userland/)
     target_include_directories(webcontent PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/..)
     target_link_libraries(webcontent PRIVATE LibAudio LibCore LibFileSystem LibGfx LibIPC LibJS LibMain LibWeb LibWebSocket LibProtocol LibWebView LibImageDecoderClient)
     target_sources(webcontent PUBLIC FILE_SET ladybird TYPE HEADERS
-        BASE_DIRS ${SERENITY_SOURCE_DIR}
+        BASE_DIRS ${LADYBIRD_SOURCE_DIR}
         FILES ../FontPlugin.h
               ../ImageCodecPlugin.h
     )
     target_sources(webcontent PUBLIC FILE_SET server TYPE HEADERS
-        BASE_DIRS ${SERENITY_SOURCE_DIR}/Userland/Services
+        BASE_DIRS ${LADYBIRD_SOURCE_DIR}/Userland/Services
         FILES ${WEBCONTENT_SOURCE_DIR}/ConnectionFromClient.h
               ${WEBCONTENT_SOURCE_DIR}/ConsoleGlobalEnvironmentExtensions.h
               ${WEBCONTENT_SOURCE_DIR}/Forward.h
@@ -78,8 +78,8 @@ else()
     target_link_libraries(WebContent PRIVATE webcontent)
 endif()
 
-target_include_directories(WebContent PRIVATE ${SERENITY_SOURCE_DIR}/Userland/Services/)
-target_include_directories(WebContent PRIVATE ${SERENITY_SOURCE_DIR}/Userland/)
+target_include_directories(WebContent PRIVATE ${LADYBIRD_SOURCE_DIR}/Userland/Services/)
+target_include_directories(WebContent PRIVATE ${LADYBIRD_SOURCE_DIR}/Userland/)
 target_include_directories(WebContent PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/..)
 target_link_libraries(WebContent PRIVATE LibAudio LibCore LibFileSystem LibGfx LibImageDecoderClient LibIPC LibJS LibMain LibSQL LibWeb LibWebSocket LibProtocol LibWebView LibURL)
 

--- a/Ladybird/WebDriver/CMakeLists.txt
+++ b/Ladybird/WebDriver/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(WEBDRIVER_SOURCE_DIR ${SERENITY_SOURCE_DIR}/Userland/Services/WebDriver)
+set(WEBDRIVER_SOURCE_DIR ${LADYBIRD_SOURCE_DIR}/Userland/Services/WebDriver)
 
 set(SOURCES
     ${WEBDRIVER_SOURCE_DIR}/Client.cpp
@@ -12,7 +12,7 @@ add_executable(WebDriver ${SOURCES})
 
 target_include_directories(WebDriver PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..)
 target_include_directories(WebDriver PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/..)
-target_include_directories(WebDriver PRIVATE ${SERENITY_SOURCE_DIR}/Userland)
-target_include_directories(WebDriver PRIVATE ${SERENITY_SOURCE_DIR}/Userland/Services)
+target_include_directories(WebDriver PRIVATE ${LADYBIRD_SOURCE_DIR}/Userland)
+target_include_directories(WebDriver PRIVATE ${LADYBIRD_SOURCE_DIR}/Userland/Services)
 target_link_libraries(WebDriver PRIVATE LibCore LibFileSystem LibGfx LibIPC LibJS LibMain LibWeb LibWebSocket LibWebView)
 add_dependencies(WebDriver headless-browser)

--- a/Ladybird/WebWorker/CMakeLists.txt
+++ b/Ladybird/WebWorker/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(WEBWORKER_SOURCE_DIR ${SERENITY_SOURCE_DIR}/Userland/Services/WebWorker)
+set(WEBWORKER_SOURCE_DIR ${LADYBIRD_SOURCE_DIR}/Userland/Services/WebWorker)
 
 set(CMAKE_AUTOMOC OFF)
 set(CMAKE_AUTORCC OFF)
@@ -16,11 +16,11 @@ set(WEBWORKER_SOURCES
 
 add_library(webworker STATIC ${WEBWORKER_SOURCES})
 
-target_include_directories(webworker PRIVATE ${SERENITY_SOURCE_DIR}/Userland/Services/)
-target_include_directories(webworker PRIVATE ${SERENITY_SOURCE_DIR}/Userland/)
+target_include_directories(webworker PRIVATE ${LADYBIRD_SOURCE_DIR}/Userland/Services/)
+target_include_directories(webworker PRIVATE ${LADYBIRD_SOURCE_DIR}/Userland/)
 target_include_directories(webworker PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/..)
 target_link_libraries(webworker PUBLIC LibCore LibFileSystem LibGfx LibIPC LibJS LibProtocol LibWeb LibWebView LibLocale LibImageDecoderClient LibMain LibSQL LibURL)
 
 add_executable(WebWorker main.cpp)
-target_include_directories(WebWorker PRIVATE ${SERENITY_SOURCE_DIR}/Userland/)
+target_include_directories(WebWorker PRIVATE ${LADYBIRD_SOURCE_DIR}/Userland/)
 target_link_libraries(WebWorker PRIVATE webworker)

--- a/Ladybird/cmake/AndroidExtras.cmake
+++ b/Ladybird/cmake/AndroidExtras.cmake
@@ -6,7 +6,7 @@
 #
 # Copy resources into tarball for inclusion in /assets of APK
 #
-set(LADYBIRD_RESOURCE_ROOT "${SERENITY_SOURCE_DIR}/Base/res")
+set(LADYBIRD_RESOURCE_ROOT "${LADYBIRD_SOURCE_DIR}/Base/res")
 macro(copy_res_folder folder)
     add_custom_target(copy-${folder}
         COMMAND ${CMAKE_COMMAND} -E copy_directory
@@ -25,12 +25,12 @@ copy_res_folder(color-palettes)
 copy_res_folder(cursor-themes)
 add_custom_target(copy-autoplay-allowlist
     COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        "${SERENITY_SOURCE_DIR}/Base/home/anon/.config/BrowserAutoplayAllowlist.txt"
+        "${LADYBIRD_SOURCE_DIR}/Base/home/anon/.config/BrowserAutoplayAllowlist.txt"
         "asset-bundle/res/ladybird/BrowserAutoplayAllowlist.txt"
 )
 add_custom_target(copy-content-filters
     COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        "${SERENITY_SOURCE_DIR}/Base/home/anon/.config/BrowserContentFilters.txt"
+        "${LADYBIRD_SOURCE_DIR}/Base/home/anon/.config/BrowserContentFilters.txt"
         "asset-bundle/res/ladybird/BrowserContentFilters.txt"
 )
 add_custom_target(copy-certs

--- a/Ladybird/cmake/EnableLagom.cmake
+++ b/Ladybird/cmake/EnableLagom.cmake
@@ -4,13 +4,13 @@
 
 set(BUILD_LAGOM ON CACHE INTERNAL "Build all Lagom targets")
 
-set(LAGOM_SOURCE_DIR "${SERENITY_SOURCE_DIR}/Meta/Lagom")
+set(LAGOM_SOURCE_DIR "${LADYBIRD_SOURCE_DIR}/Meta/Lagom")
 set(LAGOM_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/Lagom")
 
 # FIXME: Setting target_include_directories on Lagom libraries might make this unnecessary?
-include_directories(${SERENITY_SOURCE_DIR})
-include_directories(${SERENITY_SOURCE_DIR}/Userland/Services)
-include_directories(${SERENITY_SOURCE_DIR}/Userland/Libraries)
+include_directories(${LADYBIRD_SOURCE_DIR})
+include_directories(${LADYBIRD_SOURCE_DIR}/Userland/Services)
+include_directories(${LADYBIRD_SOURCE_DIR}/Userland/Libraries)
 include_directories(${LAGOM_BINARY_DIR})
 include_directories(${LAGOM_BINARY_DIR}/Userland/Services)
 include_directories(${LAGOM_BINARY_DIR}/Userland/Libraries)

--- a/Ladybird/cmake/InstallRules.cmake
+++ b/Ladybird/cmake/InstallRules.cmake
@@ -33,7 +33,7 @@ install(TARGETS ${ladybird_helper_processes}
     DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}
 )
 
-include("${SERENITY_SOURCE_DIR}/Meta/Lagom/get_linked_lagom_libraries.cmake")
+include("${LADYBIRD_SOURCE_DIR}/Meta/Lagom/get_linked_lagom_libraries.cmake")
 foreach (application IN LISTS ladybird_applications)
   get_linked_lagom_libraries("${application}" "${application}_lagom_libraries")
   list(APPEND all_required_lagom_libraries "${${application}_lagom_libraries}")

--- a/Ladybird/cmake/ResourceFiles.cmake
+++ b/Ladybird/cmake/ResourceFiles.cmake
@@ -1,5 +1,5 @@
-file(STRINGS "${SERENITY_SOURCE_DIR}/Meta/emoji-file-list.txt" EMOJI)
-list(TRANSFORM EMOJI PREPEND "${SERENITY_SOURCE_DIR}/Base/res/emoji/")
+file(STRINGS "${LADYBIRD_SOURCE_DIR}/Meta/emoji-file-list.txt" EMOJI)
+list(TRANSFORM EMOJI PREPEND "${LADYBIRD_SOURCE_DIR}/Base/res/emoji/")
 
 set(FONTS
     CsillaBold10.font
@@ -14,7 +14,7 @@ set(FONTS
     KaticaRegular12.font
     SerenitySans-Regular.ttf
 )
-list(TRANSFORM FONTS PREPEND "${SERENITY_SOURCE_DIR}/Base/res/fonts/")
+list(TRANSFORM FONTS PREPEND "${LADYBIRD_SOURCE_DIR}/Base/res/fonts/")
 
 set(16x16_ICONS
     app-browser.png
@@ -60,9 +60,9 @@ set(BROWSER_ICONS
     dom-tree.png
     local-storage.png
 )
-list(TRANSFORM 16x16_ICONS PREPEND "${SERENITY_SOURCE_DIR}/Base/res/icons/16x16/")
-list(TRANSFORM 32x32_ICONS PREPEND "${SERENITY_SOURCE_DIR}/Base/res/icons/32x32/")
-list(TRANSFORM BROWSER_ICONS PREPEND "${SERENITY_SOURCE_DIR}/Base/res/icons/browser/")
+list(TRANSFORM 16x16_ICONS PREPEND "${LADYBIRD_SOURCE_DIR}/Base/res/icons/16x16/")
+list(TRANSFORM 32x32_ICONS PREPEND "${LADYBIRD_SOURCE_DIR}/Base/res/icons/32x32/")
+list(TRANSFORM BROWSER_ICONS PREPEND "${LADYBIRD_SOURCE_DIR}/Base/res/icons/browser/")
 
 set(WEB_RESOURCES
     about.html
@@ -75,20 +75,20 @@ set(WEB_TEMPLATES
     error.html
     version.html
 )
-list(TRANSFORM WEB_RESOURCES PREPEND "${SERENITY_SOURCE_DIR}/Base/res/ladybird/")
-list(TRANSFORM WEB_TEMPLATES PREPEND "${SERENITY_SOURCE_DIR}/Base/res/ladybird/templates/")
+list(TRANSFORM WEB_RESOURCES PREPEND "${LADYBIRD_SOURCE_DIR}/Base/res/ladybird/")
+list(TRANSFORM WEB_TEMPLATES PREPEND "${LADYBIRD_SOURCE_DIR}/Base/res/ladybird/templates/")
 
 set(THEMES
     Default.ini
     Dark.ini
 )
-list(TRANSFORM THEMES PREPEND "${SERENITY_SOURCE_DIR}/Base/res/themes/")
+list(TRANSFORM THEMES PREPEND "${LADYBIRD_SOURCE_DIR}/Base/res/themes/")
 
 set(CONFIG_RESOURCES
     BrowserAutoplayAllowlist.txt
     BrowserContentFilters.txt
 )
-list(TRANSFORM CONFIG_RESOURCES PREPEND "${SERENITY_SOURCE_DIR}/Base/home/anon/.config/")
+list(TRANSFORM CONFIG_RESOURCES PREPEND "${LADYBIRD_SOURCE_DIR}/Base/home/anon/.config/")
 
 set(DOWNLOADED_RESOURCES
     cacert.pem

--- a/Meta/HeaderCheck/generate_all.py
+++ b/Meta/HeaderCheck/generate_all.py
@@ -59,12 +59,12 @@ def run(root_path, arch):
 
 
 if __name__ == '__main__':
-    if 'SERENITY_SOURCE_DIR' not in os.environ:
-        print('Must set SERENITY_SOURCE_DIR first!', file=sys.stderr)
+    if 'LADYBIRD_SOURCE_DIR' not in os.environ:
+        print('Must set LADYBIRD_SOURCE_DIR first!', file=sys.stderr)
         exit(1)
     if len(sys.argv) == 2:
-        run(os.environ['SERENITY_SOURCE_DIR'], sys.argv[1])
+        run(os.environ['LADYBIRD_SOURCE_DIR'], sys.argv[1])
     else:
-        print('Usage: SERENITY_SOURCE_DIR=/path/to/serenity {} SERENITY_BUILD_ARCH'
+        print('Usage: LADYBIRD_SOURCE_DIR=/path/to/serenity {} SERENITY_BUILD_ARCH'
               .format(sys.argv[0]), file=sys.stderr)
         exit(1)

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -631,7 +631,7 @@ if (BUILD_LAGOM)
             NAME JS
             COMMAND test-js --show-progress=false
         )
-        set_tests_properties(JS PROPERTIES ENVIRONMENT SERENITY_SOURCE_DIR=${SERENITY_PROJECT_ROOT})
+        set_tests_properties(JS PROPERTIES ENVIRONMENT LADYBIRD_SOURCE_DIR=${SERENITY_PROJECT_ROOT})
 
         # Extra tests from Tests/LibJS
         lagom_test(../../Tests/LibJS/test-invalid-unicode-js.cpp LIBS LibJS)
@@ -648,7 +648,7 @@ if (BUILD_LAGOM)
         )
         set_tests_properties(WasmParser PROPERTIES
             SKIP_RETURN_CODE 1
-            ENVIRONMENT SERENITY_SOURCE_DIR=${SERENITY_PROJECT_ROOT}
+            ENVIRONMENT LADYBIRD_SOURCE_DIR=${SERENITY_PROJECT_ROOT}
         )
 
         # FIXME: When we are using CMake >= 3.21, the library installations can be replaced with RUNTIME_DEPENDENCIES.
@@ -687,7 +687,7 @@ endif()
 if (NOT "$ENV{LAGOM_TARGET}" STREQUAL "")
     add_custom_target(run-lagom-target
         COMMAND "${CMAKE_COMMAND}"
-            -E env "SERENITY_SOURCE_DIR=${SERENITY_PROJECT_ROOT}" "$<TARGET_FILE:$ENV{LAGOM_TARGET}>"
+            -E env "LADYBIRD_SOURCE_DIR=${SERENITY_PROJECT_ROOT}" "$<TARGET_FILE:$ENV{LAGOM_TARGET}>"
             $ENV{LAGOM_ARGS}
 
         WORKING_DIRECTORY "$<TARGET_PROPERTY:$ENV{LAGOM_TARGET},LAGOM_WORKING_DIRECTORY>"

--- a/Meta/ShellCompletions/zsh/_serenity
+++ b/Meta/ShellCompletions/zsh/_serenity
@@ -6,10 +6,10 @@ get_top_dir() {
 
 get_lagom_executables() {
     # Make completion work with user-defined source directory.
-    SERENITY_SOURCE_DIR="${SERENITY_SOURCE_DIR:-$(get_top_dir)}"
+    LADYBIRD_SOURCE_DIR="${LADYBIRD_SOURCE_DIR:-$(get_top_dir)}"
     # If the Lagom binary directory is missing, this creates an empty list instead of erroring.
     # Known false positives need to be filtered manually; please add new ones.
-    find "${SERENITY_SOURCE_DIR}/Build/lagom" -mindepth 1 -type f -executable -not -name '*.so*' \
+    find "${LADYBIRD_SOURCE_DIR}/Build/lagom" -mindepth 1 -type f -executable -not -name '*.so*' \
         -not \( -name 'SQLServer' -o -name 'a.out' -o -name 'CMake*.bin' \) \
         -printf '%f\n' 2>/dev/null || true
 }

--- a/Meta/check-markdown.sh
+++ b/Meta/check-markdown.sh
@@ -18,10 +18,10 @@ if [ -z "${MARKDOWN_CHECK_BINARY:-}" ] ; then
     MARKDOWN_CHECK_BINARY="Build/lagom/bin/markdown-check"
 fi
 
-if [ -z "$SERENITY_SOURCE_DIR" ] ; then
-    SERENITY_SOURCE_DIR=$(pwd -P)
-    export SERENITY_SOURCE_DIR
+if [ -z "$LADYBIRD_SOURCE_DIR" ] ; then
+    LADYBIRD_SOURCE_DIR=$(pwd -P)
+    export LADYBIRD_SOURCE_DIR
 fi
 
 # shellcheck disable=SC2086 # Word splitting is intentional here
-find AK Base Documentation Meta Tests Userland -path Tests/LibWeb/WPT/wpt -prune -o -type f -name '*.md' -print0 | xargs -0 "${MARKDOWN_CHECK_BINARY}" -b "${SERENITY_SOURCE_DIR}/Base" $EXTRA_MARKDOWN_CHECK_ARGS README.md CONTRIBUTING.md
+find AK Base Documentation Meta Tests Userland -path Tests/LibWeb/WPT/wpt -prune -o -type f -name '*.md' -print0 | xargs -0 "${MARKDOWN_CHECK_BINARY}" -b "${LADYBIRD_SOURCE_DIR}/Base" $EXTRA_MARKDOWN_CHECK_ARGS README.md CONTRIBUTING.md

--- a/Meta/install-ports-tree.sh
+++ b/Meta/install-ports-tree.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
-SERENITY_PORTS_DIR="${SERENITY_SOURCE_DIR}/Build/${SERENITY_ARCH}/Root/usr/Ports"
+SERENITY_PORTS_DIR="${LADYBIRD_SOURCE_DIR}/Build/${SERENITY_ARCH}/Root/usr/Ports"
 
-for file in $(git ls-files "${SERENITY_SOURCE_DIR}/Ports"); do
+for file in $(git ls-files "${LADYBIRD_SOURCE_DIR}/Ports"); do
     if [ "$(basename "$file")" != ".hosted_defs.sh" ]; then
-        target=${SERENITY_PORTS_DIR}/$(realpath --relative-to="${SERENITY_SOURCE_DIR}/Ports" "$file")
+        target=${SERENITY_PORTS_DIR}/$(realpath --relative-to="${LADYBIRD_SOURCE_DIR}/Ports" "$file")
         mkdir -p "$(dirname "$target")" && cp "$file" "$target"
     fi
 done

--- a/Meta/ladybird.sh
+++ b/Meta/ladybird.sh
@@ -76,7 +76,7 @@ is_valid_target() {
 }
 
 create_build_dir() {
-    cmake -GNinja "${CMAKE_ARGS[@]}" -S "$SERENITY_SOURCE_DIR/Meta/Lagom" -B "$BUILD_DIR"
+    cmake -GNinja "${CMAKE_ARGS[@]}" -S "$LADYBIRD_SOURCE_DIR/Meta/Lagom" -B "$BUILD_DIR"
 }
 
 cmd_with_target() {
@@ -86,14 +86,14 @@ cmd_with_target() {
     CMAKE_ARGS+=("-DCMAKE_C_COMPILER=${CC}")
     CMAKE_ARGS+=("-DCMAKE_CXX_COMPILER=${CXX}")
 
-    if [ ! -d "$SERENITY_SOURCE_DIR" ]; then
-        SERENITY_SOURCE_DIR="$(get_top_dir)"
-        export SERENITY_SOURCE_DIR
+    if [ ! -d "$LADYBIRD_SOURCE_DIR" ]; then
+        LADYBIRD_SOURCE_DIR="$(get_top_dir)"
+        export LADYBIRD_SOURCE_DIR
     fi
-    BUILD_DIR="$SERENITY_SOURCE_DIR/Build/lagom"
-    CMAKE_ARGS+=("-DCMAKE_INSTALL_PREFIX=$SERENITY_SOURCE_DIR/Build/lagom-install")
-    CMAKE_ARGS+=("-DSERENITY_CACHE_DIR=${SERENITY_SOURCE_DIR}/Build/caches")
-    export PATH="$SERENITY_SOURCE_DIR/Toolchain/Local/cmake/bin":$PATH
+    BUILD_DIR="$LADYBIRD_SOURCE_DIR/Build/lagom"
+    CMAKE_ARGS+=("-DCMAKE_INSTALL_PREFIX=$LADYBIRD_SOURCE_DIR/Build/lagom-install")
+    CMAKE_ARGS+=("-DSERENITY_CACHE_DIR=${LADYBIRD_SOURCE_DIR}/Build/caches")
+    export PATH="$LADYBIRD_SOURCE_DIR/Toolchain/Local/cmake/bin":$PATH
 }
 
 ensure_target() {
@@ -117,10 +117,10 @@ build_target() {
     if [ "${CMD_ARGS[0]}" = "ladybird" ]; then
         EXTRA_CMAKE_ARGS=("-DENABLE_LAGOM_LADYBIRD=ON")
     fi
-    cmake -S "$SERENITY_SOURCE_DIR/Meta/Lagom" -B "$BUILD_DIR" -DBUILD_LAGOM=ON "${EXTRA_CMAKE_ARGS[@]}"
+    cmake -S "$LADYBIRD_SOURCE_DIR/Meta/Lagom" -B "$BUILD_DIR" -DBUILD_LAGOM=ON "${EXTRA_CMAKE_ARGS[@]}"
 
     # Get either the environment MAKEJOBS or all processors via CMake
-    [ -z "$MAKEJOBS" ] && MAKEJOBS=$(cmake -P "$SERENITY_SOURCE_DIR/Meta/CMake/processor-count.cmake")
+    [ -z "$MAKEJOBS" ] && MAKEJOBS=$(cmake -P "$LADYBIRD_SOURCE_DIR/Meta/CMake/processor-count.cmake")
 
     # With zero args, we are doing a standard "build"
     # With multiple args, we are doing an install/run
@@ -137,11 +137,11 @@ delete_target() {
 
 build_cmake() {
     echo "CMake version too old: build_cmake"
-    ( cd "$SERENITY_SOURCE_DIR/Toolchain" && ./BuildCMake.sh )
+    ( cd "$LADYBIRD_SOURCE_DIR/Toolchain" && ./BuildCMake.sh )
 }
 
 ensure_toolchain() {
-    if [ "$(cmake -P "$SERENITY_SOURCE_DIR"/Meta/CMake/cmake-version.cmake)" -ne 1 ]; then
+    if [ "$(cmake -P "$LADYBIRD_SOURCE_DIR"/Meta/CMake/cmake-version.cmake)" -ne 1 ]; then
         build_cmake
     fi
 }

--- a/Tests/LibWeb/WPT/run.sh
+++ b/Tests/LibWeb/WPT/run.sh
@@ -4,14 +4,14 @@ set -eo pipefail
 
 SCRIPT_DIR="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
 
-if [ -z "$SERENITY_SOURCE_DIR" ]
+if [ -z "$LADYBIRD_SOURCE_DIR" ]
 then
-    SERENITY_SOURCE_DIR="$(realpath "${SCRIPT_DIR}/../../../")"
-    export SERENITY_SOURCE_DIR
+    LADYBIRD_SOURCE_DIR="$(realpath "${SCRIPT_DIR}/../../../")"
+    export LADYBIRD_SOURCE_DIR
 fi
 
 
-: "${WEBDRIVER_BINARY:=$(env PATH="${SERENITY_SOURCE_DIR}/Build/lagom/bin/Ladybird.app/Contents/MacOS:${SERENITY_SOURCE_DIR}/Build/lagom/bin:${SERENITY_SOURCE_DIR}/Meta/Lagom/Build/bin:${PATH}" \
+: "${WEBDRIVER_BINARY:=$(env PATH="${LADYBIRD_SOURCE_DIR}/Build/lagom/bin/Ladybird.app/Contents/MacOS:${LADYBIRD_SOURCE_DIR}/Build/lagom/bin:${LADYBIRD_SOURCE_DIR}/Meta/Lagom/Build/bin:${PATH}" \
                          which WebDriver)}"
 update_expectations_metadata=false
 remove_wpt_repository=false
@@ -82,7 +82,7 @@ python3 ./wpt/wpt run ladybird \
                   --metadata ./metadata \
                   --manifest ./MANIFEST.json \
                   --webdriver-arg="--certificate=${PWD}/wpt/tools/certs/cacert.pem" \
-                  --webdriver-arg="--certificate=${SERENITY_SOURCE_DIR}/Build/lagom/cacert.pem" \
+                  --webdriver-arg="--certificate=${LADYBIRD_SOURCE_DIR}/Build/lagom/cacert.pem" \
                   --log-raw "${wpt_run_log_filename}"
 
 # Update expectations metadata files if requested

--- a/Tests/LibWeb/rebaseline-libweb-test
+++ b/Tests/LibWeb/rebaseline-libweb-test
@@ -15,6 +15,6 @@ fi
 input_dir=$(dirname $t)
 expected_dir=$(echo $input_dir | sed s/input/expected/)
 test_name=$(basename $t .html)
-cd $SERENITY_SOURCE_DIR/Build/lagom
+cd $LADYBIRD_SOURCE_DIR/Build/lagom
 mkdir -p $expected_dir
-./bin/headless-browser -r $SERENITY_SOURCE_DIR/Build/lagom/share/Lagom $mode_flag --layout-test-mode $input_dir/$test_name.html > $expected_dir/$test_name.txt
+./bin/headless-browser -r $LADYBIRD_SOURCE_DIR/Build/lagom/share/Lagom $mode_flag --layout-test-mode $input_dir/$test_name.html > $expected_dir/$test_name.txt

--- a/Userland/Libraries/LibTest/JavaScriptTestRunnerMain.cpp
+++ b/Userland/Libraries/LibTest/JavaScriptTestRunnerMain.cpp
@@ -142,13 +142,13 @@ int main(int argc, char** argv)
 #ifdef AK_OS_SERENITY
         test_root = LexicalPath::join("/home/anon/Tests"sv, ByteString::formatted("{}-tests", program_name.split_view('-').last())).string();
 #else
-        char* serenity_source_dir = getenv("SERENITY_SOURCE_DIR");
-        if (!serenity_source_dir) {
-            warnln("No test root given, {} requires the SERENITY_SOURCE_DIR environment variable to be set", g_program_name);
+        char* ladybird_source_dir = getenv("LADYBIRD_SOURCE_DIR");
+        if (!ladybird_source_dir) {
+            warnln("No test root given, {} requires the LADYBIRD_SOURCE_DIR environment variable to be set", g_program_name);
             return 1;
         }
-        test_root = ByteString::formatted("{}/{}", serenity_source_dir, g_test_root_fragment);
-        common_path = ByteString::formatted("{}/Userland/Libraries/LibJS/Tests/test-common.js", serenity_source_dir);
+        test_root = ByteString::formatted("{}/{}", ladybird_source_dir, g_test_root_fragment);
+        common_path = ByteString::formatted("{}/Userland/Libraries/LibJS/Tests/test-common.js", ladybird_source_dir);
 #endif
     }
     if (!FileSystem::is_directory(test_root)) {
@@ -160,12 +160,12 @@ int main(int argc, char** argv)
 #ifdef AK_OS_SERENITY
         common_path = "/home/anon/Tests/js-tests/test-common.js";
 #else
-        char* serenity_source_dir = getenv("SERENITY_SOURCE_DIR");
-        if (!serenity_source_dir) {
-            warnln("No test root given, {} requires the SERENITY_SOURCE_DIR environment variable to be set", g_program_name);
+        char* ladybird_source_dir = getenv("LADYBIRD_SOURCE_DIR");
+        if (!ladybird_source_dir) {
+            warnln("No test root given, {} requires the LADYBIRD_SOURCE_DIR environment variable to be set", g_program_name);
             return 1;
         }
-        common_path = ByteString::formatted("{}/Userland/Libraries/LibJS/Tests/test-common.js", serenity_source_dir);
+        common_path = ByteString::formatted("{}/Userland/Libraries/LibJS/Tests/test-common.js", ladybird_source_dir);
 #endif
     }
 


### PR DESCRIPTION
In order to have checkouts of both SerenityOS and Ladybird, we need to use a different environment variable for Ladybird.