### PR TITLE
nix: Add python3 to nix devshell

### DIFF
--- a/Ladybird/default.nix
+++ b/Ladybird/default.nix
@@ -7,6 +7,7 @@ mkShell.override { stdenv = gcc13Stdenv; } {
     libxcrypt
     ninja
     pkg-config
+    python3
     qt6.qtbase
     qt6.qtbase.dev
     qt6.qtmultimedia


### PR DESCRIPTION
Ladybird needs python3 in order to build, but the devshell doesn't include it.