### PR TITLE
Fix fonts on NixOS and any other XDG-compliant distro with unusual directory structure

### DIFF
--- a/Userland/Libraries/LibGfx/Font/FontDatabase.cpp
+++ b/Userland/Libraries/LibGfx/Font/FontDatabase.cpp
@@ -31,6 +31,9 @@ void FontDatabase::load_all_fonts_from_uri(StringView uri)
 {
     auto root_or_error = Core::Resource::load_from_uri(uri);
     if (root_or_error.is_error()) {
+        if (root_or_error.error().is_errno() && root_or_error.error().code() == ENOENT) {
+            return;
+        }
         dbgln("FontDatabase::load_all_fonts_from_uri('{}'): {}", uri, root_or_error.error());
         return;
     }


### PR DESCRIPTION
NixOS doesn't have `/usr/share/fonts`, so Ladybird was only loading the default bitmap font. This fixes that by replacing hardcoded paths (`/usr/share/fonts`, `/usr/local/share/fonts`, `$HOME/.local/share/fonts`) with their XDG base directory equivalents (with fallbacks included so nothing changes on systems where `$XDG_DATA_HOME` or `$XDG_DATA_DIRS` are unset). It also silences the warnings when nonexistent directories are returned from `StandardPaths.cpp::font_directories()`, since that is to be expected with the updated code that checks for more possible directories.