### PR TITLE
Meta: Add new top-level CMakeLists, default to Build/ladybird

### DIFF
--- a/.github/workflows/lagom-template.yml
+++ b/.github/workflows/lagom-template.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Create Build Environment
         if: ${{ inputs.fuzzer == 'NO_FUZZ' }}
-        working-directory: ${{ github.workspace }}/Meta/Lagom
+        working-directory: ${{ github.workspace }}
         run: |
           cmake -GNinja -B Build \
             -DBUILD_LAGOM=ON \
@@ -96,13 +96,13 @@ jobs:
 
       - name: Create Build Environment
         if: ${{ inputs.fuzzer == 'FUZZ' }}
-        working-directory: ${{ github.workspace }}/Meta/Lagom
+        working-directory: ${{ github.workspace }}
         run: |
           set -e
 
-          cmake -GNinja -B tools-build \
+          cmake -GNinja -S Meta/Lagom -B ${{ github.workspace }}/tools-build \
             -DBUILD_LAGOM=OFF \
-            -DCMAKE_INSTALL_PREFIX=tool-install \
+            -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/tool-install \
             -DSERENITY_CACHE_DIR=${{ github.workspace }}/Build/caches \
             -DCMAKE_C_COMPILER=gcc-13 \
             -DCMAKE_CXX_COMPILER=g++-13 \
@@ -110,32 +110,32 @@ jobs:
 
           ninja -C tools-build install
 
-          cmake -GNinja -B Build \
+          cmake -GNinja -S Meta/Lagom -B Build \
             -DBUILD_LAGOM=ON \
             -DENABLE_FUZZERS_LIBFUZZER=ON \
             -DENABLE_ADDRESS_SANITIZER=ON \
             -DSERENITY_CACHE_DIR=${{ github.workspace }}/Build/caches \
             -DCMAKE_C_COMPILER=${{ steps.build-parameters.outputs.host_cc }} \
             -DCMAKE_CXX_COMPILER=${{ steps.build-parameters.outputs.host_cxx }} \
-            -DCMAKE_PREFIX_PATH=tool-install
+            -DCMAKE_PREFIX_PATH=${{ github.workspace }}/tool-install
 
       # === BUILD ===
 
       - name: Build
-        working-directory: ${{ github.workspace }}/Meta/Lagom/Build
+        working-directory: ${{ github.workspace }}/Build
         run: |
           set -e
           cmake --build .
-          cmake --install . --strip --prefix ${{ github.workspace }}/Meta/Lagom/Install
+          cmake --install . --strip --prefix ${{ github.workspace }}/Install
 
       - name: Enable the Ladybird Qt chrome
         if: ${{ inputs.os_name == 'macOS' && inputs.fuzzer == 'NO_FUZZ' }}
-        working-directory: ${{ github.workspace }}/Meta/Lagom
+        working-directory: ${{ github.workspace }}
         run: cmake -B Build -DENABLE_QT=ON
 
       - name: Build the Ladybird Qt chrome
         if: ${{ inputs.os_name == 'macOS' && inputs.fuzzer == 'NO_FUZZ' }}
-        working-directory: ${{ github.workspace }}/Meta/Lagom/Build
+        working-directory: ${{ github.workspace }}/Build
         run: cmake --build .
 
       - name: Save Caches
@@ -149,7 +149,7 @@ jobs:
 
       - name: Test
         if: ${{ inputs.fuzzer == 'NO_FUZZ' }}
-        working-directory: ${{ github.workspace }}/Meta/Lagom/Build
+        working-directory: ${{ github.workspace }}/Build
         run: ninja test
         env:
           CTEST_OUTPUT_ON_FAILURE: 1
@@ -162,7 +162,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: libweb-test-artifacts-${{ inputs.os_name }}
-          path: ${{ github.workspace }}/Meta/Lagom/Build/Ladybird/test-dumps
+          path: ${{ github.workspace }}/Build/Ladybird/test-dumps
           retention-days: 7
           if-no-files-found: ignore
 
@@ -181,7 +181,7 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: |
           set -e
-          git ls-files '*.ipc' | xargs ./Meta/Lagom/Build/bin/IPCMagicLinter
+          git ls-files '*.ipc' | xargs ./Build/bin/IPCMagicLinter
         env:
           ASAN_OPTIONS: 'strict_string_checks=1:check_initialization_order=1:strict_init_order=1:detect_stack_use_after_return=1:allocator_may_return_null=1'
           UBSAN_OPTIONS: 'print_stacktrace=1:print_summary=1:halt_on_error=1'

--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,8 @@
 *.cflags
 *.cxxflags
 *.autosave
-Meta/Lagom/build
-Build
+build*
+Build*
 Toolchain/Tarballs
 Toolchain/Build
 Toolchain/Local
@@ -23,8 +23,6 @@ compile_commands.json
 .idea/
 cmake-build-debug/
 output/
-run-local.sh
-sync-local.sh
 .vim/
 .exrc
 .helix/

--- a/.ycm_extra_conf.py
+++ b/.ycm_extra_conf.py
@@ -32,42 +32,12 @@
 # For more information, please refer to <http://unlicense.org/>
 
 import os
-import subprocess
 import ycm_core
 
 DIR_OF_THIS_SCRIPT = os.path.abspath(os.path.dirname(__file__))
 SOURCE_EXTENSIONS = ['.cpp', '.c']
 
-gcc_path = None
-for serenity_arch in ['x86_64', 'aarch64']:
-    candidate_gcc_path = os.path.join(
-        DIR_OF_THIS_SCRIPT, 'Toolchain',
-        'Local', serenity_arch, 'bin', f'{serenity_arch}-pc-serenity-gcc'
-    )
-    if os.path.isfile(candidate_gcc_path):
-        gcc_path = candidate_gcc_path
-        break
-
-serenity_flags = [
-    '-D__serenity__',
-    '-D__unix__'
-]
-
-if gcc_path:
-    gcc_output = subprocess.check_output(
-      [gcc_path, '-E', '-Wp,-v', '-'],
-      stdin=subprocess.DEVNULL, stderr=subprocess.STDOUT
-    ).rstrip().decode('utf8').split("\n")
-
-    for line in gcc_output:
-        if not line.startswith(' '):
-            continue
-        include_path = line.lstrip()
-        if '/../Build/' in include_path:
-            continue
-        serenity_flags.extend(('-isystem', include_path))
-
-database = ycm_core.CompilationDatabase(os.path.join(DIR_OF_THIS_SCRIPT, f'Build/{serenity_arch}'))
+database = ycm_core.CompilationDatabase(os.path.join(DIR_OF_THIS_SCRIPT, 'Build/ladybird'))
 
 
 def is_header_file(filename):
@@ -85,14 +55,7 @@ def find_corresponding_source_file(filename):
     return filename
 
 
-def startswith_any(string, prefixes):
-    for prefix in prefixes:
-        if string.startswith(prefix):
-            return True
-    return False
-
-
-def Settings(**kwargs):
+def Settings(**kwargs):  # noqa: N802
     if kwargs['language'] != 'cfamily':
         return {}
     # If the file is a header, try to find the corresponding source file and
@@ -107,16 +70,8 @@ def Settings(**kwargs):
     if not compilation_info.compiler_flags_:
         return {}
 
-    ignored_flags = [
-        '--sysroot',
-        '-fzero-call-used-regs=used-gpr',
-    ]
-
-    final_flags = [flag for flag in compilation_info.compiler_flags_ if not startswith_any(flag, ignored_flags)]
-    final_flags.extend(serenity_flags)
-
     return {
-        'flags': final_flags,
+        'flags': compilation_info.compiler_flags_,
         'include_paths_relative_to_dir': DIR_OF_THIS_SCRIPT,
         'override_filename': filename
     }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,76 @@
+cmake_minimum_required(VERSION 3.25)
+
+project(ladybird
+        VERSION 0.1.0
+        LANGUAGES C CXX
+        DESCRIPTION "Ladybird Web Browser"
+        HOMEPAGE_URL "https://ladybird.dev"
+)
+
+if (ANDROID OR IOS)
+    set(BUILD_SHARED_LIBS OFF)
+endif()
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+set(LADYBIRD_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+list(APPEND CMAKE_MODULE_PATH "${LADYBIRD_SOURCE_DIR}/Meta/CMake")
+
+include(Ladybird/cmake/EnableLagom.cmake)
+include(use_linker)
+include(lagom_compile_options)
+include(lagom_install_options)
+
+if (ENABLE_ADDRESS_SANITIZER)
+    add_compile_options(-fsanitize=address -fno-omit-frame-pointer)
+    add_link_options(-fsanitize=address)
+endif()
+
+if (ENABLE_MEMORY_SANITIZER)
+    add_compile_options(-fsanitize=memory -fsanitize-memory-track-origins -fno-omit-frame-pointer)
+    add_link_options(-fsanitize=memory -fsanitize-memory-track-origins)
+endif()
+
+if (ENABLE_UNDEFINED_SANITIZER)
+    add_compile_options(-fsanitize=undefined -fno-omit-frame-pointer)
+    if (UNDEFINED_BEHAVIOR_IS_FATAL)
+        add_compile_options(-fno-sanitize-recover=undefined)
+    endif()
+    if (APPLE AND CMAKE_CXX_COMPILER_ID MATCHES "Clang$" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "17")
+        add_compile_options(-fno-sanitize=function)
+    endif()
+    add_link_options(-fsanitize=undefined)
+endif()
+
+if (HAIKU)
+    # Haiku needs some extra compile definitions to make important stuff in its headers available.
+    add_compile_definitions(_DEFAULT_SOURCE)
+    add_compile_definitions(_GNU_SOURCE)
+    add_compile_definitions(__USE_GNU)
+endif()
+
+add_compile_options(-DAK_DONT_REPLACE_STD)
+add_compile_options(-Wno-expansion-to-defined)
+add_compile_options(-Wno-user-defined-literals)
+
+if (ANDROID OR APPLE)
+    serenity_option(ENABLE_QT OFF CACHE BOOL "Build ladybird application using Qt GUI")
+else()
+    serenity_option(ENABLE_QT ON CACHE BOOL "Build ladybird application using Qt GUI")
+endif()
+
+if (ANDROID AND ENABLE_QT)
+    message(STATUS "Disabling Qt for Android")
+    set(ENABLE_QT OFF CACHE BOOL "" FORCE)
+endif()
+
+if (ENABLE_QT)
+    set(CMAKE_AUTOMOC ON)
+    set(CMAKE_AUTORCC ON)
+    set(CMAKE_AUTOUIC ON)
+    find_package(Qt6 REQUIRED COMPONENTS Core Widgets Network)
+endif()
+
+include(CTest) # for BUILD_TESTING option, default ON
+
+add_subdirectory(Ladybird)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,58 @@
+{
+  "version": 6,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 25,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "default",
+      "displayName": "Default Config",
+      "description": "Default build using Ninja generator",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/Build/ladybird",
+      "cacheVariables": {
+        "SERENITY_CACHE_DIR": "${sourceDir}/Build/caches"
+      },
+      "environment": {
+        "LADYBIRD_SOURCE_DIR": "${sourceDir}"
+      },
+      "vendor": {
+        "jetbrains.com/clion": {
+          "toolchain": "Default"
+        }
+      }
+    },
+    {
+      "name": "Sanitizer",
+      "inherits": "default",
+      "displayName": "Sanitizer Config",
+      "description": "Debug build using Sanitizers",
+      "binaryDir": "${sourceDir}/Build/ladybird-sanitizers",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "ENABLE_UNDEFINED_SANITIZER": "ON",
+        "ENABLE_ADDRESS_SANITIZER": "ON"
+      }
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "default",
+      "configurePreset": "default",
+      "output": {
+        "outputOnFailure": true
+      },
+      "execution": {
+        "noTestsAction": "error",
+        "stopOnFailure": true
+      }
+    },
+    {
+      "name": "Sanitizer",
+      "inherits": "default",
+      "configurePreset": "Sanitizer"
+    }
+  ]
+}

--- a/Documentation/AdvancedBuildInstructions.md
+++ b/Documentation/AdvancedBuildInstructions.md
@@ -6,7 +6,7 @@ This file covers a few advanced scenarios that go beyond what the basic build gu
 
 The `Meta/ladybird.sh` script provides an abstraction over the build targets which are made available by CMake. The
 following build targets cannot be accessed through the script and have to be used directly by changing the current
-directory to `Build/x86_64` and then running `ninja <target>`:
+directory to `Build/ladybird` and then running `ninja <target>`:
 
 - `ninja check-style`: Runs the same linters the CI does to verify project style on changed files
 - `ninja lint-shell-scripts`: Checks style of shell scripts in the source tree with shellcheck
@@ -58,7 +58,7 @@ For example, boolean options such as `ENABLE_<setting>` or `<component_name>_DEB
 
 ```console
 # Reconfigure an existing binary directory with process debug enabled
-$ cmake -B Build/x86_64 -DPROCESS_DEBUG=ON
+$ cmake -B Build/ladbyird -DPROCESS_DEBUG=ON
 ```
 
 For more information on how the CMake cache works, see the CMake guide for [Running CMake](https://cmake.org/runningcmake/). Additional context is available in the CMake documentation for

--- a/Documentation/BuildInstructionsLadybird.md
+++ b/Documentation/BuildInstructionsLadybird.md
@@ -109,14 +109,10 @@ Qt chrome, install the Qt dependencies for your platform, and enable the Qt chro
 
 ```bash
 # From /path/to/ladybird
-cmake -S Meta/Lagom -B Build/lagom -DENABLE_QT=ON
+cmake -B Build/ladybird -DENABLE_QT=ON
 ```
 
 To re-disable the Qt chrome, run the above command with `-DENABLE_QT=OFF`.
-
-```bash
-cmake -S Meta/Lagom -B Build/lagom -DENABLE_LAGOM_LADYBIRD=OFF -DENABLE_LAGOM_LIBWEB=OFF -DBUILD_LAGOM=OFF
-```
 
 ### Resource files
 
@@ -142,7 +138,7 @@ a suitable C++ compiler (g++ >= 13, clang >= 14, Apple Clang >= 14.3) via the CM
 CMAKE_C_COMPILER cmake options.
 
 ```
-cmake -GNinja -S Ladybird -B Build/ladybird
+cmake -GNinja -B Build/ladybird
 # optionally, add -DCMAKE_CXX_COMPILER=<suitable compiler> -DCMAKE_C_COMPILER=<matching c compiler>
 cmake --build Build/ladybird
 ninja -C Build/ladybird run
@@ -186,16 +182,9 @@ Now breakpoints, stepping and variable inspection will work.
 ### Debugging with Xcode on macOS
 
 The `ladybird.sh` build script does not know how to generate Xcode projects, so creating the project must be done manually.
-To be compatible with the `ladybird.sh` script, a few extra options are required. If there is a previous Lagom build directory, CMake will likely complain that the generator has changed.
 
 ```
-cmake -GXcode -S Meta/Lagom -B Build/lagom -DBUILD_LAGOM=ON -DENABLE_LAGOM_LADYBIRD=ON
-```
-
-Alternatively, if you don't need your ladybird build to be compatible with `ladybird.sh`, you can use Ladybird as the source directory like so:
-
-```
-cmake -GXcode -S Ladybird -B Build/ladybird
+cmake -GXcode -B Build/ladybird
 ```
 
 After generating an Xcode project into the specified build directory, you can open `ladybird.xcodeproj` in Xcode. The project has a ton of targets, many of which are generated code.
@@ -213,7 +202,7 @@ When running Ladybird, make sure that XDG_RUNTIME_DIR is set, or it will immedia
 doesn't find a writable directory for its sockets.
 
 ```
-CMAKE_PREFIX_PATH=/usr/lib/qt/6.2/lib/amd64/cmake cmake -GNinja -S Ladybird -B Build/ladybird -DCMAKE_C_COMPILER=/usr/bin/clang -DCMAKE_CXX_COMPILER=/usr/bin/clang++
+CMAKE_PREFIX_PATH=/usr/lib/qt/6.2/lib/amd64/cmake cmake -GNinja -B Build/ladybird -DCMAKE_C_COMPILER=/usr/bin/clang -DCMAKE_CXX_COMPILER=/usr/bin/clang++
 cmake --build Build/ladybird
 XDG_RUNTIME_DIR=/var/tmp ninja -C Build/ladybird run
 ```
@@ -224,7 +213,7 @@ Haiku is supported by Ladybird out of the box. The steps are the same as on Open
 additional environment variables are required.
 
 ```
-cmake -GNinja -S Ladybird -B Build/ladybird
+cmake -GNinja -B Build/ladybird
 cmake --build Build/ladybird
 ninja -C Build/ladybird run
 ```

--- a/Documentation/CLionConfiguration.md
+++ b/Documentation/CLionConfiguration.md
@@ -4,7 +4,7 @@ CLion can integrate with CMake to provide code comprehension features.
 
 After opening the `ladybird` repository in CLion as a new project, the "`Open Project Wizard`" window will open, from here set the following fields:
 
-(Assuming you use `Ninja` as the build system and configured the CMake build directory to `Build/lagom`)
+(Assuming you use `Ninja` as the build system and configured the CMake build directory to `Build/ladybird`)
 
 `CMake Options`:
 ```
@@ -12,7 +12,7 @@ After opening the `ladybird` repository in CLion as a new project, the "`Open Pr
 -GNinja
 ```
 
-`Build Directory`: `Build/lagom`
+`Build Directory`: `Build/ladybird`
 
 If you already have the project open, you can go to `File -> Settings -> Build, Execution, Deployment -> CMake` to find these options.
 

--- a/Documentation/EmacsConfiguration.md
+++ b/Documentation/EmacsConfiguration.md
@@ -9,18 +9,15 @@ can use the following `.clangd` file placed in the project root:
 
 ```yaml
 CompileFlags:
-  CompilationDatabase: Build/lagom
+  CompilationDatabase: Build/ladybird
 
 Diagnostics:
   UnusedIncludes: None
   MissingIncludes: None
 ```
 
-You will need to change `/path/to/ladybird` and change `13.1.0` to
-whatever your GCC toolchain version at the time is.
-
 Run cmake (`Meta/ladybird.sh run ladybird` or similar) at least once for this
-to work, as it will generate the `Build/lagom/compile_commands.json`
+to work, as it will generate the `Build/ladybird/compile_commands.json`
 that is needed by `clangd`.
 
 ### lsp-mode

--- a/Documentation/HelixConfiguration.md
+++ b/Documentation/HelixConfiguration.md
@@ -4,7 +4,7 @@ Helix comes with support for `clangd` and `clang-format` out of the box! However
 The following `.clangd` should be placed in the project root:
 ```yaml
 CompileFlags:
-  CompilationDatabase: Build/lagom
+  CompilationDatabase: Build/ladybird
 
 Diagnostics:
   UnusedIncludes: None
@@ -21,5 +21,3 @@ args = ["--header-insertion=never"]
 name = "cpp"
 language-servers = ["ladybird"]
 ```
-
-> Make sure to replace `/path/to/ladybird` with the actual path in the snippet above!

--- a/Documentation/NvimConfiguration.md
+++ b/Documentation/NvimConfiguration.md
@@ -180,7 +180,7 @@ nmap <silent>gs :CocCommand clangd.switchSourceHeader vsplit<CR>
 > **Note**: Every time a new source is added or the compilation commands get adjusted
 (through CMake) you need to rerun `./Meta/ladybird.sh rebuild`.
 
-Link `ln -s /path/to/ladybird/Build/lagom/compile_commands.json /path/to/ladybird/compile_commands.json`.
+Link `ln -s /path/to/ladybird/Build/ladybird/compile_commands.json /path/to/ladybird/compile_commands.json`.
 
 Create `/path/to/ladybird/.clangd` (replace `/path/to/ladybird`
 with your ladybird directory) with content of the clangd section in the

--- a/Documentation/VSCodeConfiguration.md
+++ b/Documentation/VSCodeConfiguration.md
@@ -17,12 +17,12 @@ Clangd has the best support for cross-compiling workflows, especially if configu
 
 The official clangd extension can be used for C++ comprehension. It is recommended in general, as it is most likely to work on all platforms.
 
-clangd uses ``compile_commands.json`` files to understand the project. CMake will generate these in Build/lagom.
+clangd uses ``compile_commands.json`` files to understand the project. CMake will generate these in Build/ladybird.
 Depending on which configuration you use most, set the CompilationDatabase configuration item in the below ``.clangd`` file accordingly. It goes at the root of your checkout (``ladybird/.clangd``):
 
 ```yaml
 CompileFlags:
-  CompilationDatabase: Build/lagom
+  CompilationDatabase: Build/ladybird
   
 Diagnostics:
   UnusedIncludes: None
@@ -60,10 +60,10 @@ following ``c_cpp_properties.json`` to circumvent some errors. Even with the con
             "name": "ladybird-gcc",
             "includePath": [
                 "${workspaceFolder}",
-                "${workspaceFolder}/Build/lagom/",
-                "${workspaceFolder}/Build/lagom/Userland",
-                "${workspaceFolder}/Build/lagom/Userland/Libraries",
-                "${workspaceFolder}/Build/lagom/Userland/Services",
+                "${workspaceFolder}/Build/ladybird/",
+                "${workspaceFolder}/Build/ladybird/Userland",
+                "${workspaceFolder}/Build/ladybird/Userland/Libraries",
+                "${workspaceFolder}/Build/ladybird/Userland/Services",
                 "${workspaceFolder}/Userland",
                 "${workspaceFolder}/Userland/Libraries",
                 "${workspaceFolder}/Userland/Services"
@@ -74,7 +74,7 @@ following ``c_cpp_properties.json`` to circumvent some errors. Even with the con
             "cStandard": "c17",
             "cppStandard": "c++23",
             "intelliSenseMode": "linux-gcc-x86",
-            "compileCommands": "Build/lagom/compile_commands.json",
+            "compileCommands": "Build/ladybird/compile_commands.json",
             "compilerArgs": [
                 "-Wall",
                 "-Wextra",
@@ -83,16 +83,16 @@ following ``c_cpp_properties.json`` to circumvent some errors. Even with the con
             "browse": {
                 "path": [
                     "${workspaceFolder}",
-                    "${workspaceFolder}/Build/lagom/",
-                    "${workspaceFolder}/Build/lagom/Userland",
-                    "${workspaceFolder}/Build/lagom/Userland/Libraries",
-                    "${workspaceFolder}/Build/lagom/Userland/Services",
+                    "${workspaceFolder}/Build/ladybird/",
+                    "${workspaceFolder}/Build/ladybird/Userland",
+                    "${workspaceFolder}/Build/ladybird/Userland/Libraries",
+                    "${workspaceFolder}/Build/ladybird/Userland/Services",
                     "${workspaceFolder}/Userland",
                     "${workspaceFolder}/Userland/Libraries",
                     "${workspaceFolder}/Userland/Services"
                 ],
                 "limitSymbolsToIncludedHeaders": true,
-                "databaseFilename": "${workspaceFolder}/Build/lagom/"
+                "databaseFilename": "${workspaceFolder}/Build/ladybird/"
             }
         }
     ],
@@ -165,7 +165,7 @@ The following three example tasks should suffice in most situations, and allow y
                     "base": "$gcc",
                     "fileLocation": [
                         "relative",
-                        "${workspaceFolder}/Build/lagom"
+                        "${workspaceFolder}/Build/ladybird"
                     ]
                 }
             ],
@@ -199,14 +199,14 @@ The following three example tasks should suffice in most situations, and allow y
                     "base": "$gcc",
                     "fileLocation": [
                         "relative",
-                        "${workspaceFolder}/Build/lagom"
+                        "${workspaceFolder}/Build/ladybird"
                     ]
                 },
                 {
                     "source": "gcc",
                     "fileLocation": [
                         "relative",
-                        "${workspaceFolder}/Build/lagom"
+                        "${workspaceFolder}/Build/ladybird"
                     ],
                     "pattern": [
                         {
@@ -241,14 +241,14 @@ The following three example tasks should suffice in most situations, and allow y
                     "base": "$gcc",
                     "fileLocation": [
                         "relative",
-                        "${workspaceFolder}/Build/lagom"
+                        "${workspaceFolder}/Build/ladybird"
                     ]
                 },
                 {
                     "source": "gcc",
                     "fileLocation": [
                         "relative",
-                        "${workspaceFolder}/Build/lagom"
+                        "${workspaceFolder}/Build/ladybird"
                     ],
                     "pattern": [
                         {
@@ -275,7 +275,7 @@ The following three example tasks should suffice in most situations, and allow y
                     ],
                     "fileLocation": [
                         "relative",
-                        "${workspaceFolder}/Build/lagom"
+                        "${workspaceFolder}/Build/ladybird"
                     ]
                 }
             ]

--- a/Ladybird/CMakeLists.txt
+++ b/Ladybird/CMakeLists.txt
@@ -1,101 +1,3 @@
-cmake_minimum_required(VERSION 3.23)
-
-project(ladybird
-    VERSION 0.0.1
-    LANGUAGES CXX
-    DESCRIPTION "Ladybird Web Browser"
-)
-
-include(GNUInstallDirs)
-
-if (ANDROID OR IOS)
-    set(BUILD_SHARED_LIBS OFF)
-endif()
-
-# FIXME: The rpath steps from lagom_install_rules.cmake do not produce a working binary
-#        in the build directory on macOS.
-#        We need to copy the libs into the build directory bundle as the install rules do.
-set(CMAKE_SKIP_BUILD_RPATH FALSE)
-set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
-# See slide 100 of the following ppt :^)
-# https://crascit.com/wp-content/uploads/2019/09/Deep-CMake-For-Library-Authors-Craig-Scott-CppCon-2019.pdf
-if (NOT APPLE)
-    set(CMAKE_INSTALL_RPATH $ORIGIN;$ORIGIN/../${CMAKE_INSTALL_LIBDIR})
-endif()
-set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
-
-set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-
-if (ENABLE_ADDRESS_SANITIZER)
-    add_compile_options(-fsanitize=address -fno-omit-frame-pointer)
-    add_link_options(-fsanitize=address)
-endif()
-
-if (ENABLE_MEMORY_SANITIZER)
-    add_compile_options(-fsanitize=memory -fsanitize-memory-track-origins -fno-omit-frame-pointer)
-    add_link_options(-fsanitize=memory -fsanitize-memory-track-origins)
-endif()
-
-if (ENABLE_UNDEFINED_SANITIZER)
-    add_compile_options(-fsanitize=undefined -fno-omit-frame-pointer)
-    if (UNDEFINED_BEHAVIOR_IS_FATAL)
-        add_compile_options(-fno-sanitize-recover=undefined)
-    endif()
-    if (APPLE AND CMAKE_CXX_COMPILER_ID MATCHES "Clang$" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "17")
-        add_compile_options(-fno-sanitize=function)
-    endif()
-    add_link_options(-fsanitize=undefined)
-endif()
-
-if (HAIKU)
-    # Haiku needs some extra compile definitions to make important stuff in its headers available.
-    add_compile_definitions(_DEFAULT_SOURCE)
-    add_compile_definitions(_GNU_SOURCE)
-    add_compile_definitions(__USE_GNU)
-endif()
-
-# Lagom
-set(LADYBIRD_CUSTOM_TARGET_SUFFIX "-ladybird")
-if (PROJECT_IS_TOP_LEVEL)
-    set(LADYBIRD_CUSTOM_TARGET_SUFFIX "")
-endif()
-
-if (PROJECT_IS_TOP_LEVEL)
-    get_filename_component(
-        LADYBIRD_SOURCE_DIR "${ladybird_SOURCE_DIR}/.."
-        ABSOLUTE
-    )
-    list(APPEND CMAKE_MODULE_PATH "${LADYBIRD_SOURCE_DIR}/Meta/CMake")
-    include(cmake/EnableLagom.cmake)
-    include(use_linker)
-    include(lagom_compile_options)
-    include(lagom_install_options)
-else()
-    # FIXME: Use LADYBIRD_SOURCE_DIR in Lagom/CMakeLists.txt
-    set(LADYBIRD_SOURCE_DIR "${SERENITY_PROJECT_ROOT}")
-endif()
-
-add_compile_options(-DAK_DONT_REPLACE_STD)
-add_compile_options(-Wno-expansion-to-defined)
-add_compile_options(-Wno-user-defined-literals)
-
-if (ANDROID OR APPLE)
-    serenity_option(ENABLE_QT OFF CACHE BOOL "Build ladybird application using Qt GUI")
-else()
-    serenity_option(ENABLE_QT ON CACHE BOOL "Build ladybird application using Qt GUI")
-endif()
-
-if (ANDROID AND ENABLE_QT)
-    message(STATUS "Disabling Qt for Android")
-    set(ENABLE_QT OFF CACHE BOOL "" FORCE)
-endif()
-
-if (ENABLE_QT)
-    set(CMAKE_AUTOMOC ON)
-    set(CMAKE_AUTORCC ON)
-    set(CMAKE_AUTOUIC ON)
-    find_package(Qt6 REQUIRED COMPONENTS Core Widgets Network)
-endif()
 
 set(SOURCES
     HelperProcess.cpp
@@ -218,13 +120,13 @@ if (ANDROID)
     include(cmake/AndroidExtras.cmake)
 endif()
 
-add_custom_target(run${LADYBIRD_CUSTOM_TARGET_SUFFIX}
+add_custom_target(run-ladybird
     COMMAND "${CMAKE_COMMAND}" -E env "LADYBIRD_SOURCE_DIR=${LADYBIRD_SOURCE_DIR}" "$<TARGET_FILE:ladybird>" $ENV{LAGOM_ARGS}
     USES_TERMINAL
     VERBATIM
 )
 
-add_custom_target(debug${LADYBIRD_CUSTOM_TARGET_SUFFIX}
+add_custom_target(debug-ladybird
     COMMAND "${CMAKE_COMMAND}" -E env "LADYBIRD_SOURCE_DIR=${LADYBIRD_SOURCE_DIR}" gdb -ex "set follow-fork-mode child" "$<TARGET_FILE:ladybird>"
     USES_TERMINAL
 )
@@ -260,6 +162,12 @@ function(create_ladybird_bundle target_name)
             COMMAND "${CMAKE_COMMAND}" -E make_directory "${bundle_dir}/Contents/Resources"
             COMMAND "iconutil" --convert icns "${LADYBIRD_SOURCE_DIR}/Ladybird/Icons/macos/app_icon.iconset" --output "${bundle_dir}/Contents/Resources/app_icon.icns"
         )
+
+        # Note: This symlink is removed in the install commands
+        # This makes the bundle in the build directory *NOT* relocatable
+        add_custom_command(TARGET ${target_name} POST_BUILD
+            COMMAND "${CMAKE_COMMAND}" -E create_symlink "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}" "${bundle_dir}/Contents/lib"
+        )
     endif()
 endfunction()
 
@@ -280,7 +188,6 @@ if(NOT CMAKE_SKIP_INSTALL_RULES)
     include(cmake/InstallRules.cmake)
 endif()
 
-include(CTest)
 if (BUILD_TESTING)
     add_test(
         NAME LibWeb
@@ -289,7 +196,7 @@ if (BUILD_TESTING)
     add_test(
         NAME WPT
         CONFIGURATIONS Integration
-        COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../Tests/LibWeb/WPT/run.sh
+        COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../Tests/LibWeb/WPT/run.sh --webdriver-binary=$<TARGET_FILE:WebDriver>
     )
     set_tests_properties(LibWeb WPT PROPERTIES
         DEPENDS ladybird

--- a/Ladybird/cmake/EnableLagom.cmake
+++ b/Ladybird/cmake/EnableLagom.cmake
@@ -15,5 +15,4 @@ include_directories(${LAGOM_BINARY_DIR})
 include_directories(${LAGOM_BINARY_DIR}/Userland/Services)
 include_directories(${LAGOM_BINARY_DIR}/Userland/Libraries)
 
-# We set EXCLUDE_FROM_ALL to make sure that only required Lagom libraries are built
-add_subdirectory("${LAGOM_SOURCE_DIR}" "${LAGOM_BINARY_DIR}" EXCLUDE_FROM_ALL)
+add_subdirectory("${LAGOM_SOURCE_DIR}" "${LAGOM_BINARY_DIR}")

--- a/Tests/LibWeb/WPT/run.sh
+++ b/Tests/LibWeb/WPT/run.sh
@@ -11,7 +11,7 @@ then
 fi
 
 
-: "${WEBDRIVER_BINARY:=$(env PATH="${LADYBIRD_SOURCE_DIR}/Build/lagom/bin/Ladybird.app/Contents/MacOS:${LADYBIRD_SOURCE_DIR}/Build/lagom/bin:${LADYBIRD_SOURCE_DIR}/Meta/Lagom/Build/bin:${PATH}" \
+: "${WEBDRIVER_BINARY:=$(env PATH="${LADYBIRD_SOURCE_DIR}/Build/ladybird/bin/Ladybird.app/Contents/MacOS:${LADYBIRD_SOURCE_DIR}/Build/ladybird/bin:${LADYBIRD_SOURCE_DIR}/Build/bin:${PATH}" \
                          which WebDriver)}"
 update_expectations_metadata=false
 remove_wpt_repository=false


### PR DESCRIPTION
This still preserves the ability to use Meta/Lagom as a top-level project, but kinda breaks using Meta/Lagom to build Ladybird. Hopefully we can discourage that from now on, and use Meta/Lagom as a top level project only for things like Fuzzers and cross-compile tools builds.