### PR TITLE
Ladybird/Qt: Set find in page query to selected text on initial focus

### DIFF
--- a/Ladybird/Qt/FindInPageWidget.cpp
+++ b/Ladybird/Qt/FindInPageWidget.cpp
@@ -105,6 +105,9 @@ void FindInPageWidget::focusInEvent(QFocusEvent* event)
 {
     QWidget::focusInEvent(event);
     m_find_text->setFocus();
+    auto selected_text = m_content_view->selected_text();
+    if (!selected_text.is_empty())
+        m_find_text->setText(qstring_from_ak_string(selected_text));
     m_find_text->selectAll();
 }
 


### PR DESCRIPTION
This matches the behavior of other browsers.

Example:

https://github.com/LadybirdWebBrowser/ladybird/assets/2817754/21b2a2c8-6c28-49ed-a0b7-2fec4e78f047

