### PR TITLE
Ladybird/Qt: Draw line box borders for all tabs when option is toggled

### DIFF
--- a/Ladybird/Qt/BrowserWindow.cpp
+++ b/Ladybird/Qt/BrowserWindow.cpp
@@ -336,12 +336,15 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, WebView::Cook
 
     debug_menu->addSeparator();
 
-    auto* show_line_box_borders_action = new QAction("Show Line Box Borders", this);
-    show_line_box_borders_action->setCheckable(true);
-    debug_menu->addAction(show_line_box_borders_action);
-    QObject::connect(show_line_box_borders_action, &QAction::triggered, this, [this, show_line_box_borders_action] {
-        bool state = show_line_box_borders_action->isChecked();
-        debug_request("set-line-box-borders", state ? "on" : "off");
+    m_show_line_box_borders_action = new QAction("Show Line Box Borders", this);
+    m_show_line_box_borders_action->setCheckable(true);
+    debug_menu->addAction(m_show_line_box_borders_action);
+    QObject::connect(m_show_line_box_borders_action, &QAction::triggered, this, [this] {
+        bool state = m_show_line_box_borders_action->isChecked();
+        for (auto index = 0; index < m_tabs_container->count(); ++index) {
+            auto tab = verify_cast<Tab>(m_tabs_container->widget(index));
+            tab->set_line_box_borders(state);
+        }
     });
 
     debug_menu->addSeparator();
@@ -677,6 +680,7 @@ void BrowserWindow::initialize_tab(Tab* tab)
     create_close_button_for_tab(tab);
 
     tab->focus_location_editor();
+    tab->set_line_box_borders(m_show_line_box_borders_action->isChecked());
 }
 
 void BrowserWindow::activate_tab(int index)

--- a/Ladybird/Qt/BrowserWindow.h
+++ b/Ladybird/Qt/BrowserWindow.h
@@ -184,6 +184,7 @@ private:
     QAction* m_find_in_page_action { nullptr };
     QAction* m_view_source_action { nullptr };
     QAction* m_inspect_dom_node_action { nullptr };
+    QAction* m_show_line_box_borders_action { nullptr };
 
     SettingsDialog* m_settings_dialog { nullptr };
 

--- a/Ladybird/Qt/Tab.cpp
+++ b/Ladybird/Qt/Tab.cpp
@@ -956,4 +956,9 @@ void Tab::close_sub_widgets()
     close_widget_window(m_inspector_widget);
 }
 
+void Tab::set_line_box_borders(bool enabled)
+{
+    debug_request("set-line-box-borders", enabled ? "on" : "off");
+}
+
 }

--- a/Ladybird/Qt/Tab.h
+++ b/Ladybird/Qt/Tab.h
@@ -65,6 +65,8 @@ public:
 
     void update_hover_label();
 
+    void set_line_box_borders(bool);
+
 public slots:
     void focus_location_editor();
     void location_edit_return_pressed();


### PR DESCRIPTION
Previously, line box borders were only set for the current tab when the option was toggled.


https://github.com/LadybirdWebBrowser/ladybird/assets/2817754/e72b9b2e-5a91-478c-a375-861a77bcece6

