### PR TITLE
Documentation: Remove links to outdated guides

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -1,20 +1,16 @@
 # Ladybird Documentation
 
-Serenity development moves quickly, so some of these might be out of date. Please let us know if something here is wrong, or submit a PR with any additions or corrections! If you have any questions that are not answered here or in the [FAQ](FAQ.md), you are welcome to ask on [Discord](../README.md#get-in-touch-and-participate).
+Ladybird development moves quickly, so some of these might be out of date. Please let us know if something here is wrong,
+or submit a PR with any additions or corrections! If you have any questions that are not answered here or in the [FAQ](FAQ.md), 
+you are welcome to ask on [Discord](../README.md#get-in-touch-and-participate).
 
 ## Building and Running
-* [Build Instructions](BuildInstructions.md)
+* [Build Instructions](BuildInstructionsLadybird.md)
 * [Advanced Build Instructions](AdvancedBuildInstructions.md)
 * [Troubleshooting](Troubleshooting.md)
 * [Running Tests](RunningTests.md)
 * [Setting Up Self-Hosted Runners](SelfHostedRunners.md)
 * [Profiling the Build](BuildProfilingInstructions.md)
-
-### OS-specific
-Make sure to read the basic [Build Instructions](BuildInstructionsLadybird.md) first.
-* [Building on Windows](BuildInstructionsWindows.md)
-* [Building on macOS](BuildInstructionsMacOS.md)
-* [Building on Linux](BuildInstructionsOther.md)
 
 ## Configuring Editors
 * [CLion](CLionConfiguration.md)
@@ -40,3 +36,4 @@ Make sure to read the basic [Build Instructions](BuildInstructionsLadybird.md) f
 * [LibWeb: From Loading to Painting](Browser/LibWebFromLoadingToPainting.md)
 * [How to Add an IDL File](Browser/AddNewIDLFile.md)
 * [LibWeb Code Style & Patterns](Browser/Patterns.md)
+


### PR DESCRIPTION
The documentation for ladybird contained links to outdated and already removed guides, such as os specific build instructions. I also changed `Serenity development` to `Ladybird developement`.

I also fixed a typo in the link to the build instructions, see #55 