### PR TITLE
LibWeb: Extend text selection when left clicking and holding shift

### DIFF
--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -426,7 +426,11 @@ bool EventHandler::handle_mousedown(CSSPixelPoint position, CSSPixelPoint screen
                     auto& realm = document->realm();
                     m_navigable->set_cursor_position(DOM::Position::create(realm, *paintable->dom_node(), result->index_in_node));
                     if (auto selection = document->get_selection()) {
-                        (void)selection->set_base_and_extent(*paintable->dom_node(), result->index_in_node, *paintable->dom_node(), result->index_in_node);
+                        if (modifiers & KeyModifier::Mod_Shift) {
+                            (void)selection->set_base_and_extent(*selection->anchor_node(), selection->anchor_offset(), *paintable->dom_node(), result->index_in_node);
+                        } else {
+                            (void)selection->set_base_and_extent(*paintable->dom_node(), result->index_in_node, *paintable->dom_node(), result->index_in_node);
+                        }
                     }
                     m_in_mouse_selection = true;
                 }


### PR DESCRIPTION
This matches the behavior of other browsers.

Example usage:


https://github.com/LadybirdWebBrowser/ladybird/assets/2817754/71642dcb-2d0b-4732-b203-1118a00e1fc0

