### PR TITLE
LibWeb: Ensure anchor node is not null when extending selection

### DIFF
--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -433,8 +433,9 @@ bool EventHandler::handle_mousedown(CSSPixelPoint viewport_position, CSSPixelPoi
                     auto& realm = document->realm();
                     m_navigable->set_cursor_position(DOM::Position::create(realm, *paintable->dom_node(), result->index_in_node));
                     if (auto selection = document->get_selection()) {
-                        if (modifiers & KeyModifier::Mod_Shift) {
-                            (void)selection->set_base_and_extent(*selection->anchor_node(), selection->anchor_offset(), *paintable->dom_node(), result->index_in_node);
+                        auto anchor_node = selection->anchor_node();
+                        if (anchor_node && modifiers & KeyModifier::Mod_Shift) {
+                            (void)selection->set_base_and_extent(*anchor_node, selection->anchor_offset(), *paintable->dom_node(), result->index_in_node);
                         } else {
                             (void)selection->set_base_and_extent(*paintable->dom_node(), result->index_in_node, *paintable->dom_node(), result->index_in_node);
                         }


### PR DESCRIPTION
Previously, clicking while holding shift without having previously made any text selection would cause a crash.

Follow-up to: #54

:sweat_smile: 
