### PR TITLE
Tests: Stop invoking UB in `AK::NeverDestroyed`'s tests

### DIFF
--- a/Tests/AK/TestNeverDestroyed.cpp
+++ b/Tests/AK/TestNeverDestroyed.cpp
@@ -44,20 +44,27 @@ TEST_CASE(should_construct_by_move)
     EXPECT_EQ(1, n->num_moves);
 }
 
-NO_SANITIZE_ADDRESS static void should_not_destroy()
-{
-    Counter* c = nullptr;
+struct DestructorChecker {
+    DestructorChecker(bool& destroyed)
+        : m_destroyed(destroyed)
     {
-        AK::NeverDestroyed<Counter> n {};
-        // note: explicit stack-use-after-scope
-        c = &n.get();
     }
-    EXPECT_EQ(0, c->num_destroys);
-}
+
+    ~DestructorChecker()
+    {
+        m_destroyed = true;
+    }
+
+    bool& m_destroyed;
+};
 
 TEST_CASE(should_not_destroy)
 {
-    should_not_destroy();
+    bool destroyed = false;
+    {
+        AK::NeverDestroyed<DestructorChecker> n(destroyed);
+    }
+    EXPECT(!destroyed);
 }
 
 TEST_CASE(should_provide_dereference_operator)


### PR DESCRIPTION
Instead of attempting a stack use-after-free by reading an out-of-scope object's data member, let's keep a flag that checks if the destructor had been called in the outer scope.

Fixes #64