### PR TITLE
UI/Qt: Set debug menu options across all tabs

### DIFF
--- a/Ladybird/Qt/BrowserWindow.cpp
+++ b/Ladybird/Qt/BrowserWindow.cpp
@@ -341,10 +341,9 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, WebView::Cook
     debug_menu->addAction(m_show_line_box_borders_action);
     QObject::connect(m_show_line_box_borders_action, &QAction::triggered, this, [this] {
         bool state = m_show_line_box_borders_action->isChecked();
-        for (auto index = 0; index < m_tabs_container->count(); ++index) {
-            auto tab = verify_cast<Tab>(m_tabs_container->widget(index));
-            tab->set_line_box_borders(state);
-        }
+        for_each_tab([state](auto& tab) {
+            tab.set_line_box_borders(state);
+        });
     });
 
     debug_menu->addSeparator();
@@ -414,30 +413,36 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, WebView::Cook
 
     debug_menu->addSeparator();
 
-    auto* enable_scripting_action = new QAction("Enable Scripting", this);
-    enable_scripting_action->setCheckable(true);
-    enable_scripting_action->setChecked(true);
-    debug_menu->addAction(enable_scripting_action);
-    QObject::connect(enable_scripting_action, &QAction::triggered, this, [this, enable_scripting_action] {
-        bool state = enable_scripting_action->isChecked();
-        debug_request("scripting", state ? "on" : "off");
+    m_enable_scripting_action = new QAction("Enable Scripting", this);
+    m_enable_scripting_action->setCheckable(true);
+    m_enable_scripting_action->setChecked(true);
+    debug_menu->addAction(m_enable_scripting_action);
+    QObject::connect(m_enable_scripting_action, &QAction::triggered, this, [this] {
+        bool state = m_enable_scripting_action->isChecked();
+        for_each_tab([state](auto& tab) {
+            tab.set_scripting(state);
+        });
     });
 
-    auto* block_pop_ups_action = new QAction("Block Pop-ups", this);
-    block_pop_ups_action->setCheckable(true);
-    block_pop_ups_action->setChecked(true);
-    debug_menu->addAction(block_pop_ups_action);
-    QObject::connect(block_pop_ups_action, &QAction::triggered, this, [this, block_pop_ups_action] {
-        bool state = block_pop_ups_action->isChecked();
-        debug_request("block-pop-ups", state ? "on" : "off");
+    m_block_pop_ups_action = new QAction("Block Pop-ups", this);
+    m_block_pop_ups_action->setCheckable(true);
+    m_block_pop_ups_action->setChecked(true);
+    debug_menu->addAction(m_block_pop_ups_action);
+    QObject::connect(m_block_pop_ups_action, &QAction::triggered, this, [this] {
+        bool state = m_block_pop_ups_action->isChecked();
+        for_each_tab([state](auto& tab) {
+            tab.set_block_popups(state);
+        });
     });
 
-    auto* enable_same_origin_policy_action = new QAction("Enable Same-Origin Policy", this);
-    enable_same_origin_policy_action->setCheckable(true);
-    debug_menu->addAction(enable_same_origin_policy_action);
-    QObject::connect(enable_same_origin_policy_action, &QAction::triggered, this, [this, enable_same_origin_policy_action] {
-        bool state = enable_same_origin_policy_action->isChecked();
-        debug_request("same-origin-policy", state ? "on" : "off");
+    m_enable_same_origin_policy_action = new QAction("Enable Same-Origin Policy", this);
+    m_enable_same_origin_policy_action->setCheckable(true);
+    debug_menu->addAction(m_enable_same_origin_policy_action);
+    QObject::connect(m_enable_same_origin_policy_action, &QAction::triggered, this, [this] {
+        bool state = m_enable_same_origin_policy_action->isChecked();
+        for_each_tab([state](auto& tab) {
+            tab.set_same_origin_policy(state);
+        });
     });
 
     auto* help_menu = m_hamburger_menu->addMenu("&Help");
@@ -680,7 +685,11 @@ void BrowserWindow::initialize_tab(Tab* tab)
     create_close_button_for_tab(tab);
 
     tab->focus_location_editor();
+
     tab->set_line_box_borders(m_show_line_box_borders_action->isChecked());
+    tab->set_scripting(m_enable_scripting_action->isChecked());
+    tab->set_block_popups(m_block_pop_ups_action->isChecked());
+    tab->set_same_origin_policy(m_enable_same_origin_policy_action->isChecked());
 }
 
 void BrowserWindow::activate_tab(int index)

--- a/Ladybird/Qt/BrowserWindow.cpp
+++ b/Ladybird/Qt/BrowserWindow.cpp
@@ -386,12 +386,15 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, WebView::Cook
         user_agent_group->addAction(action);
         spoof_user_agent_menu->addAction(action);
         QObject::connect(action, &QAction::triggered, this, [this, user_agent] {
-            debug_request("spoof-user-agent", user_agent);
-            debug_request("clear-cache"); // clear the cache to ensure requests are re-done with the new user agent
+            for_each_tab([user_agent](auto& tab) {
+                tab.set_user_agent_string(user_agent);
+            });
+            set_user_agent_string(user_agent);
         });
         return action;
     };
 
+    set_user_agent_string(Web::default_user_agent);
     auto* disable_spoofing = add_user_agent("Disabled"sv, Web::default_user_agent);
     disable_spoofing->setChecked(true);
     for (auto const& user_agent : WebView::user_agents)
@@ -404,8 +407,11 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, WebView::Cook
     QObject::connect(custom_user_agent_action, &QAction::triggered, this, [this, disable_spoofing] {
         auto user_agent = QInputDialog::getText(this, "Custom User Agent", "Enter User Agent:");
         if (!user_agent.isEmpty()) {
-            debug_request("spoof-user-agent", ak_byte_string_from_qstring(user_agent));
-            debug_request("clear-cache"); // clear the cache to ensure requests are re-done with the new user agent
+            auto user_agent_byte_string = ak_byte_string_from_qstring(user_agent);
+            for_each_tab([&](auto& tab) {
+                tab.set_user_agent_string(user_agent_byte_string);
+            });
+            set_user_agent_string(user_agent_byte_string);
         } else {
             disable_spoofing->activate(QAction::Trigger);
         }
@@ -690,6 +696,7 @@ void BrowserWindow::initialize_tab(Tab* tab)
     tab->set_scripting(m_enable_scripting_action->isChecked());
     tab->set_block_popups(m_block_pop_ups_action->isChecked());
     tab->set_same_origin_policy(m_enable_same_origin_policy_action->isChecked());
+    tab->set_user_agent_string(user_agent_string());
 }
 
 void BrowserWindow::activate_tab(int index)

--- a/Ladybird/Qt/BrowserWindow.h
+++ b/Ladybird/Qt/BrowserWindow.h
@@ -185,6 +185,9 @@ private:
     QAction* m_view_source_action { nullptr };
     QAction* m_inspect_dom_node_action { nullptr };
     QAction* m_show_line_box_borders_action { nullptr };
+    QAction* m_enable_scripting_action { nullptr };
+    QAction* m_block_pop_ups_action { nullptr };
+    QAction* m_enable_same_origin_policy_action { nullptr };
 
     SettingsDialog* m_settings_dialog { nullptr };
 

--- a/Ladybird/Qt/BrowserWindow.h
+++ b/Ladybird/Qt/BrowserWindow.h
@@ -164,6 +164,9 @@ private:
 
     void set_window_rect(Optional<Web::DevicePixels> x, Optional<Web::DevicePixels> y, Optional<Web::DevicePixels> width, Optional<Web::DevicePixels> height);
 
+    ByteString user_agent_string() const { return m_user_agent_string; }
+    void set_user_agent_string(ByteString const& user_agent_string) { m_user_agent_string = user_agent_string; }
+
     QScreen* m_current_screen;
     double m_device_pixel_ratio { 0 };
 
@@ -188,6 +191,8 @@ private:
     QAction* m_enable_scripting_action { nullptr };
     QAction* m_block_pop_ups_action { nullptr };
     QAction* m_enable_same_origin_policy_action { nullptr };
+
+    ByteString m_user_agent_string {};
 
     SettingsDialog* m_settings_dialog { nullptr };
 

--- a/Ladybird/Qt/Tab.cpp
+++ b/Ladybird/Qt/Tab.cpp
@@ -976,4 +976,11 @@ void Tab::set_scripting(bool enabled)
     debug_request("scripting", enabled ? "on" : "off");
 }
 
+void Tab::set_user_agent_string(ByteString const& user_agent)
+{
+    debug_request("spoof-user-agent", user_agent);
+    // Clear the cache to ensure requests are re-done with the new user agent.
+    debug_request("clear-cache");
+}
+
 }

--- a/Ladybird/Qt/Tab.cpp
+++ b/Ladybird/Qt/Tab.cpp
@@ -956,9 +956,24 @@ void Tab::close_sub_widgets()
     close_widget_window(m_inspector_widget);
 }
 
+void Tab::set_block_popups(bool enabled)
+{
+    debug_request("block-pop-ups", enabled ? "on" : "off");
+}
+
 void Tab::set_line_box_borders(bool enabled)
 {
     debug_request("set-line-box-borders", enabled ? "on" : "off");
+}
+
+void Tab::set_same_origin_policy(bool enabled)
+{
+    debug_request("same-origin-policy", enabled ? "on" : "off");
+}
+
+void Tab::set_scripting(bool enabled)
+{
+    debug_request("scripting", enabled ? "on" : "off");
 }
 
 }

--- a/Ladybird/Qt/Tab.h
+++ b/Ladybird/Qt/Tab.h
@@ -65,7 +65,10 @@ public:
 
     void update_hover_label();
 
+    void set_block_popups(bool);
     void set_line_box_borders(bool);
+    void set_same_origin_policy(bool);
+    void set_scripting(bool);
 
 public slots:
     void focus_location_editor();

--- a/Ladybird/Qt/Tab.h
+++ b/Ladybird/Qt/Tab.h
@@ -41,7 +41,7 @@ public:
     void forward();
     void reload();
 
-    void debug_request(ByteString const& request, ByteString const& argument);
+    void debug_request(ByteString const& request, ByteString const& argument = "");
 
     void open_file();
     void update_reset_zoom_button();
@@ -69,6 +69,7 @@ public:
     void set_line_box_borders(bool);
     void set_same_origin_policy(bool);
     void set_scripting(bool);
+    void set_user_agent_string(ByteString const&);
 
 public slots:
     void focus_location_editor();


### PR DESCRIPTION
All of the checkbox options in the Debug menu are now set across all tabs when the option is toggled. The spoof user agent option is also applied to all tabs when it is changed.

These options are also now applied to new tabs when they are created.