### PR TITLE
LibTimeZone: Read /etc/timezone for current TZ

### DIFF
--- a/Userland/Libraries/LibTimeZone/TimeZone.cpp
+++ b/Userland/Libraries/LibTimeZone/TimeZone.cpp
@@ -103,9 +103,6 @@ StringView current_time_zone()
         return "UTC"sv;
     }
 
-#ifdef AK_OS_SERENITY
-    return system_time_zone();
-#else
     static constexpr auto zoneinfo = "/zoneinfo"sv;
 
     char* real_path = realpath("/etc/localtime", nullptr);
@@ -131,7 +128,6 @@ StringView current_time_zone()
 
     // Read the system timezone file /etc/timezone
     return system_time_zone();
-#endif
 }
 
 ErrorOr<void> change_time_zone([[maybe_unused]] StringView time_zone)

--- a/Userland/Libraries/LibTimeZone/TimeZone.cpp
+++ b/Userland/Libraries/LibTimeZone/TimeZone.cpp
@@ -129,7 +129,8 @@ StringView current_time_zone()
         dbgln_if(TIME_ZONE_DEBUG, "Could not read the /etc/localtime link: {}", strerror(errno));
     }
 
-    return "UTC"sv;
+    // Read the system timezone file /etc/timezone
+    return system_time_zone();
 #endif
 }
 


### PR DESCRIPTION
Fallback to reading /etc/timezone by calling system_time_zone() when unable determine time zone from /etc/localtime.
This works on systems where /etc/localtime is a file and not a symlink.

Fixes #65