### PR TITLE
Meta: Do not pass an empty --resources flag to headless-browser

### DIFF
--- a/Ladybird/CMakeLists.txt
+++ b/Ladybird/CMakeLists.txt
@@ -137,7 +137,7 @@ endif()
 if (BUILD_TESTING)
     add_test(
         NAME LibWeb
-        COMMAND $<TARGET_FILE:headless-browser> --resources "${resource_base_dir}" --run-tests ${LADYBIRD_SOURCE_DIR}/Tests/LibWeb --dump-failed-ref-tests
+        COMMAND $<TARGET_FILE:headless-browser> --run-tests ${LADYBIRD_SOURCE_DIR}/Tests/LibWeb --dump-failed-ref-tests
     )
     add_test(
         NAME WPT

--- a/Userland/Libraries/LibProtocol/RequestClient.cpp
+++ b/Userland/Libraries/LibProtocol/RequestClient.cpp
@@ -14,6 +14,13 @@ RequestClient::RequestClient(NonnullOwnPtr<Core::LocalSocket> socket)
 {
 }
 
+void RequestClient::die()
+{
+    // FIXME: Gracefully handle this, or relaunch and reconnect to RequestServer.
+    warnln("\033[31;1mLost connection to RequestServer\033[0m");
+    VERIFY_NOT_REACHED();
+}
+
 void RequestClient::ensure_connection(URL::URL const& url, ::RequestServer::CacheLevel cache_level)
 {
     async_ensure_connection(url, cache_level);

--- a/Userland/Libraries/LibProtocol/RequestClient.h
+++ b/Userland/Libraries/LibProtocol/RequestClient.h
@@ -36,6 +36,8 @@ public:
     bool set_certificate(Badge<Request>, Request&, ByteString, ByteString);
 
 private:
+    virtual void die() override;
+
     virtual void request_started(i32, IPC::File const&) override;
     virtual void request_progress(i32, Optional<u64> const&, u64) override;
     virtual void request_finished(i32, bool, u64) override;


### PR DESCRIPTION
This fixes the running of headless-browser tests on CI.

Due to `IPC::ConnectionToServer::die` having a default implementation of `exit(0)`, we were gracefully exiting the headless-browser process when RequestServer failed to launch.