### PR TITLE
CMake: Added VCPKG_ROOT env to presets

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -16,7 +16,8 @@
         "SERENITY_CACHE_DIR": "${sourceDir}/Build/caches"
       },
       "environment": {
-        "LADYBIRD_SOURCE_DIR": "${sourceDir}"
+        "LADYBIRD_SOURCE_DIR": "${sourceDir}",
+        "VCPKG_ROOT": "${sourceDir}/Toolchain/Tarballs/vcpkg"
       },
       "vendor": {
         "jetbrains.com/clion": {


### PR DESCRIPTION
This makes the build system to detect the vcpkg when using clion and other ide