### PR TITLE
Meta: Cache VcPkg in CI, and move enablement of vcpkg to ladybird.sh and CMakePresets.json

### DIFF
--- a/.github/actions/cache-restore/action.yml
+++ b/.github/actions/cache-restore/action.yml
@@ -91,3 +91,10 @@ runs:
           key: UnicodeLocale-${{ hashFiles('Meta/CMake/locale_data.cmake') }}-${{ steps.date-stamp.outputs.timestamp }}
           restore-keys: |
               UnicodeLocale-${{ hashFiles('Meta/CMake/locale_data.cmake') }}
+
+    - name: Export vcpkg GitHub Actions cache environment variables
+      uses: actions/github-script@v7
+      with:
+        script: |
+          core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+          core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');

--- a/.github/workflows/lagom-template.yml
+++ b/.github/workflows/lagom-template.yml
@@ -23,6 +23,7 @@ env:
   LADYBIRD_SOURCE_DIR: ${{ github.workspace }}
   CCACHE_DIR: ${{ github.workspace }}/.ccache
   VCPKG_ROOT:  ${{ github.workspace }}/Toolchain/Tarballs/vcpkg
+  VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
 
 jobs:
   CI:
@@ -84,13 +85,9 @@ jobs:
         if: ${{ inputs.fuzzer == 'NO_FUZZ' }}
         working-directory: ${{ github.workspace }}
         run: |
-          cmake -GNinja -B Build \
-            -DBUILD_LAGOM=ON \
+          cmake --preset Sanitizer_CI -B Build \
             -DINCLUDE_WASM_SPEC_TESTS=ON \
             -DWASM_SPEC_TEST_SKIP_FORMATTING=ON \
-            -DENABLE_UNDEFINED_SANITIZER=ON \
-            -DENABLE_ADDRESS_SANITIZER=ON \
-            -DSERENITY_CACHE_DIR=${{ github.workspace }}/Build/caches \
             -DCMAKE_C_COMPILER=${{ steps.build-parameters.outputs.host_cc }} \
             -DCMAKE_CXX_COMPILER=${{ steps.build-parameters.outputs.host_cxx }}
 
@@ -110,11 +107,7 @@ jobs:
 
           ninja -C tools-build install
 
-          cmake -GNinja -S Meta/Lagom -B Build \
-            -DBUILD_LAGOM=ON \
-            -DENABLE_FUZZERS_LIBFUZZER=ON \
-            -DENABLE_ADDRESS_SANITIZER=ON \
-            -DSERENITY_CACHE_DIR=${{ github.workspace }}/Build/caches \
+          cmake --preset Fuzzers_CI -B Build \
             -DCMAKE_C_COMPILER=${{ steps.build-parameters.outputs.host_cc }} \
             -DCMAKE_CXX_COMPILER=${{ steps.build-parameters.outputs.host_cxx }} \
             -DCMAKE_PREFIX_PATH=${{ github.workspace }}/tool-install
@@ -149,12 +142,9 @@ jobs:
 
       - name: Test
         if: ${{ inputs.fuzzer == 'NO_FUZZ' }}
-        working-directory: ${{ github.workspace }}/Build
-        run: ninja test
+        working-directory: ${{ github.workspace }}
+        run: ctest --preset Sanitizer --output-on-failure --test-dir Build
         env:
-          CTEST_OUTPUT_ON_FAILURE: 1
-          ASAN_OPTIONS: 'strict_string_checks=1:check_initialization_order=1:strict_init_order=1:detect_stack_use_after_return=1:allocator_may_return_null=1'
-          UBSAN_OPTIONS: 'print_stacktrace=1:print_summary=1:halt_on_error=1'
           TESTS_ONLY: 1
 
       - name: Upload LibWeb Test Artifacts

--- a/.github/workflows/nightly-android.yml
+++ b/.github/workflows/nightly-android.yml
@@ -11,6 +11,7 @@ env:
   LADYBIRD_SOURCE_DIR: ${{ github.workspace }}
   CCACHE_DIR: ${{ github.workspace }}/.ccache
   VCPKG_ROOT:  ${{ github.workspace }}/Toolchain/Tarballs/vcpkg
+  VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || format('{0}-{1}', github.ref, github.run_number) }}

--- a/.github/workflows/serenity-js-artifacts.yml
+++ b/.github/workflows/serenity-js-artifacts.yml
@@ -6,6 +6,7 @@ env:
   LADYBIRD_SOURCE_DIR: ${{ github.workspace }}
   SERENITY_CCACHE_DIR: ${{ github.workspace }}/.ccache
   VCPKG_ROOT:  ${{ github.workspace }}/Toolchain/Tarballs/vcpkg
+  VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
 
 jobs:
   build-and-package:
@@ -48,11 +49,9 @@ jobs:
 
       - name: Create build directory Ubuntu
         run: |
-          cmake -S Meta/Lagom -B Build -G Ninja \
-            -DCMAKE_C_COMPILER=gcc-13 \
-            -DCMAKE_CXX_COMPILER=g++-13 \
-            -DBUILD_LAGOM=ON \
-            -DSERENITY_CACHE_DIR=${{ github.workspace }}/Build/caches
+          cmake --preset CI -B Build \
+            -DCMAKE_C_COMPILER=gcc-13
+            -DCMAKE_CXX_COMPILER=g++-13
         if: ${{ matrix.os == 'ubuntu-22.04' }}
         env:
           CCACHE_DIR: ${{ env.SERENITY_CCACHE_DIR }}
@@ -60,12 +59,10 @@ jobs:
       - name: Create build directory macOS
         run: |
           # Note: We are using Apple Clang to create Universal binary
-          cmake -S Meta/Lagom -B Build -G Ninja \
+          cmake --preset CI -B Build \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" \
-            -DCMAKE_OSX_DEPLOYMENT_TARGET="11.0" \
-            -DBUILD_LAGOM=ON \
-            -DSERENITY_CACHE_DIR=${{ github.workspace }}/Build/caches
+            -DCMAKE_OSX_DEPLOYMENT_TARGET="11.0"
         if: ${{ matrix.os == 'macos-14' }}
         env:
           CCACHE_DIR: ${{ env.SERENITY_CCACHE_DIR }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,5 @@
 cmake_minimum_required(VERSION 3.25)
 
-SET(CMAKE_TOOLCHAIN_FILE "$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake")
-set(VCPKG_INSTALL_OPTIONS --no-print-usage)
-
 project(ladybird
         VERSION 0.1.0
         LANGUAGES C CXX

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -13,11 +13,14 @@
       "generator": "Ninja",
       "binaryDir": "${sourceDir}/Build/ladybird",
       "cacheVariables": {
-        "SERENITY_CACHE_DIR": "${sourceDir}/Build/caches"
+        "SERENITY_CACHE_DIR": "${sourceDir}/Build/caches",
+        "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/Toolchain/Tarballs/vcpkg/scripts/buildsystems/vcpkg.cmake",
+        "VCPKG_INSTALL_OPTIONS": "--no-print-usage"
       },
       "environment": {
         "LADYBIRD_SOURCE_DIR": "${sourceDir}",
-        "VCPKG_ROOT": "${sourceDir}/Toolchain/Tarballs/vcpkg"
+        "VCPKG_ROOT": "${sourceDir}/Toolchain/Tarballs/vcpkg",
+        "VCPKG_BINARY_SOURCES": "clear;files,${sourceDir}/Toolchain/Build/vcpkg-binary-cache,readwrite"
       },
       "vendor": {
         "jetbrains.com/clion": {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -29,6 +29,14 @@
       }
     },
     {
+      "hidden": true,
+      "name": "vcpkg_ci",
+      "description": "Use the GitHub Actions vcpkg cache",
+      "environment": {
+        "VCPKG_BINARY_SOURCES": "clear;x-gha,readwrite"
+      }
+    },
+    {
       "name": "Sanitizer",
       "inherits": "default",
       "displayName": "Sanitizer Config",
@@ -37,6 +45,32 @@
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
         "ENABLE_UNDEFINED_SANITIZER": "ON",
+        "ENABLE_ADDRESS_SANITIZER": "ON"
+      }
+    },
+    {
+      "name": "CI",
+      "inherits": ["vcpkg_ci", "default" ],
+      "displayName": "Non-Sanitizer CI Config"
+    },
+    {
+      "name": "Sanitizer_CI",
+      "inherits": ["vcpkg_ci", "Sanitizer" ],
+      "displayName": "Sanitizer CI Config",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": ""
+      }
+    },
+    {
+      "name": "Fuzzers_CI",
+      "inherits": ["vcpkg_ci", "default" ],
+      "displayName": "Fuzzers Config",
+      "description": "Fuzzers build with GitHub Actions cache",
+      "binaryDir": "${sourceDir}/Build/ladybird-fuzzers",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "",
+        "ENABLE_QT": "OFF",
+        "ENABLE_FUZZERS_LIBFUZZER": "ON",
         "ENABLE_ADDRESS_SANITIZER": "ON"
       }
     }


### PR DESCRIPTION
Also add a vcpkg command to ladybird.sh to ensure that vcpkg is setup,
and use a local binary cache for vcpkg build and install media to
avoid cluttering $XDG_CACHE_HOME.

Ref:

Binary caching in general https://learn.microsoft.com/en-us/vcpkg/users/binarycaching#default-binary-cache
GA cache: https://learn.microsoft.com/en-us/vcpkg/consume/binary-caching-github-actions-cache
Local cache: https://learn.microsoft.com/en-us/vcpkg/consume/binary-caching-local?pivots=shell-bash
