### PR TITLE
LibWasm+AK: Validate that Wasm names are UTF-8

### DIFF
--- a/AK/Utf16View.cpp
+++ b/AK/Utf16View.cpp
@@ -105,10 +105,11 @@ ErrorOr<String> Utf16View::to_utf8(AllowInvalidCodeUnits allow_invalid_code_unit
 
             TRY(builder.try_append_code_point(static_cast<u32>(*ptr)));
         }
-    } else {
-        for (auto code_point : *this)
-            TRY(builder.try_append_code_point(code_point));
+        return builder.to_string_without_validation();
     }
+
+    for (auto code_point : *this)
+        TRY(builder.try_append_code_point(code_point));
 
     return builder.to_string();
 }

--- a/Tests/AK/TestUtf8.cpp
+++ b/Tests/AK/TestUtf8.cpp
@@ -80,6 +80,11 @@ TEST_CASE(validate_invalid_ut8)
     Utf8View utf8_6 { StringView { invalid_utf8_6, 4 } };
     EXPECT(!utf8_6.validate(valid_bytes));
     EXPECT(valid_bytes == 0);
+
+    char invalid_utf8_7[] = { (char)0xed, (char)0xa0, (char)0x80 }; // U+d800
+    Utf8View utf8_7 { StringView { invalid_utf8_7, 3 } };
+    EXPECT(!utf8_7.validate(valid_bytes, Utf8View::AllowSurrogates::No));
+    EXPECT(valid_bytes == 0);
 }
 
 TEST_CASE(validate_overlong_utf8)

--- a/Userland/Libraries/LibWasm/Types.h
+++ b/Userland/Libraries/LibWasm/Types.h
@@ -55,6 +55,7 @@ enum class ParseError {
     HugeAllocationRequested,
     OutOfMemory,
     SectionSizeMismatch,
+    InvalidUtf8,
     // FIXME: This should not exist!
     NotImplemented,
 };


### PR DESCRIPTION
The [UTF-8](https://datatracker.ietf.org/doc/html/rfc3629#page-5) standard says to reject strings with upper or lower surrogates. However, in many standards ([ECMAScript included](https://262.ecma-international.org/14.0/#sec-ecmascript-language-types-string-type)) unpaired surrogates (and therefore UTF-8 surrogates) are allowed in strings. So, this commit extends the UTF-8 validation API with `AllowSurrogates`, which will reject upper and lower surrogate characters.

Unfortunately, there are two behaviors: surrogates are allowed and surrogates not allowed. I tried to reconcile them both into one API, but I ended up just extending `Utf8View`. Let me know if that approach isn't a good idea.

Also in this PR: validating that Wasm strings are UTF-8 (which spurred the change to AK code)