### PR TITLE
LibWasm: Check data section offset for overflow during instantiation

### DIFF
--- a/Userland/Libraries/LibWasm/AbstractMachine/AbstractMachine.cpp
+++ b/Userland/Libraries/LibWasm/AbstractMachine/AbstractMachine.cpp
@@ -345,7 +345,9 @@ InstantiationResult AbstractMachine::instantiate(Module const& module, Vector<Ex
                         return;
                     auto address = main_module_instance.memories()[data.index.value()];
                     auto instance = m_store.get(address);
-                    if (data.init.size() + offset > instance->size()) {
+                    Checked<size_t> checked_offset = data.init.size();
+                    checked_offset += offset;
+                    if (checked_offset.has_overflow() || checked_offset > instance->size()) {
                         instantiation_result = InstantiationError {
                             ByteString::formatted("Data segment attempted to write to out-of-bounds memory ({}) in memory of size {}",
                                 offset, instance->size())


### PR DESCRIPTION
Small PR to fix a ubsan error (that appears when using the new spec-test generation).