### PR TITLE
LibWeb: Implement rejection by bounding box for PaintInnerBoxShadow

### DIFF
--- a/Userland/Libraries/LibWeb/Painting/Command.cpp
+++ b/Userland/Libraries/LibWeb/Painting/Command.cpp
@@ -20,6 +20,11 @@ Gfx::IntRect PaintOuterBoxShadow::bounding_rect() const
     return get_outer_box_shadow_bounding_rect(box_shadow_params);
 }
 
+Gfx::IntRect PaintInnerBoxShadow::bounding_rect() const
+{
+    return box_shadow_params.device_content_rect;
+}
+
 void PaintOuterBoxShadow::translate_by(Gfx::IntPoint const& offset)
 {
     box_shadow_params.device_content_rect.translate_by(offset);

--- a/Userland/Libraries/LibWeb/Painting/Command.cpp
+++ b/Userland/Libraries/LibWeb/Painting/Command.cpp
@@ -17,17 +17,17 @@ void DrawGlyphRun::translate_by(Gfx::IntPoint const& offset)
 
 Gfx::IntRect PaintOuterBoxShadow::bounding_rect() const
 {
-    return get_outer_box_shadow_bounding_rect(outer_box_shadow_params);
+    return get_outer_box_shadow_bounding_rect(box_shadow_params);
 }
 
 void PaintOuterBoxShadow::translate_by(Gfx::IntPoint const& offset)
 {
-    outer_box_shadow_params.device_content_rect.translate_by(offset);
+    box_shadow_params.device_content_rect.translate_by(offset);
 }
 
 void PaintInnerBoxShadow::translate_by(Gfx::IntPoint const& offset)
 {
-    outer_box_shadow_params.device_content_rect.translate_by(offset);
+    box_shadow_params.device_content_rect.translate_by(offset);
 }
 
 }

--- a/Userland/Libraries/LibWeb/Painting/Command.h
+++ b/Userland/Libraries/LibWeb/Painting/Command.h
@@ -149,6 +149,7 @@ struct PaintOuterBoxShadow {
 struct PaintInnerBoxShadow {
     PaintBoxShadowParams box_shadow_params;
 
+    [[nodiscard]] Gfx::IntRect bounding_rect() const;
     void translate_by(Gfx::IntPoint const& offset);
 };
 

--- a/Userland/Libraries/LibWeb/Painting/Command.h
+++ b/Userland/Libraries/LibWeb/Painting/Command.h
@@ -32,7 +32,7 @@
 #include <LibWeb/Painting/BorderRadiiData.h>
 #include <LibWeb/Painting/BorderRadiusCornerClipper.h>
 #include <LibWeb/Painting/GradientData.h>
-#include <LibWeb/Painting/PaintOuterBoxShadowParams.h>
+#include <LibWeb/Painting/PaintBoxShadowParams.h>
 
 namespace Web::Painting {
 
@@ -140,14 +140,14 @@ struct PaintLinearGradient {
 };
 
 struct PaintOuterBoxShadow {
-    PaintOuterBoxShadowParams outer_box_shadow_params;
+    PaintBoxShadowParams box_shadow_params;
 
     [[nodiscard]] Gfx::IntRect bounding_rect() const;
     void translate_by(Gfx::IntPoint const& offset);
 };
 
 struct PaintInnerBoxShadow {
-    PaintOuterBoxShadowParams outer_box_shadow_params;
+    PaintBoxShadowParams box_shadow_params;
 
     void translate_by(Gfx::IntPoint const& offset);
 };

--- a/Userland/Libraries/LibWeb/Painting/CommandExecutorCPU.cpp
+++ b/Userland/Libraries/LibWeb/Painting/CommandExecutorCPU.cpp
@@ -259,14 +259,14 @@ CommandResult CommandExecutorCPU::paint_linear_gradient(PaintLinearGradient cons
 CommandResult CommandExecutorCPU::paint_outer_box_shadow(PaintOuterBoxShadow const& command)
 {
     auto& painter = this->painter();
-    Web::Painting::paint_outer_box_shadow(painter, command.outer_box_shadow_params);
+    Web::Painting::paint_outer_box_shadow(painter, command.box_shadow_params);
     return CommandResult::Continue;
 }
 
 CommandResult CommandExecutorCPU::paint_inner_box_shadow(PaintInnerBoxShadow const& command)
 {
     auto& painter = this->painter();
-    Web::Painting::paint_inner_box_shadow(painter, command.outer_box_shadow_params);
+    Web::Painting::paint_inner_box_shadow(painter, command.box_shadow_params);
     return CommandResult::Continue;
 }
 

--- a/Userland/Libraries/LibWeb/Painting/CommandList.h
+++ b/Userland/Libraries/LibWeb/Painting/CommandList.h
@@ -32,7 +32,7 @@
 #include <LibWeb/Painting/BorderRadiusCornerClipper.h>
 #include <LibWeb/Painting/Command.h>
 #include <LibWeb/Painting/GradientData.h>
-#include <LibWeb/Painting/PaintOuterBoxShadowParams.h>
+#include <LibWeb/Painting/PaintBoxShadowParams.h>
 
 namespace Web::Painting {
 

--- a/Userland/Libraries/LibWeb/Painting/PaintBoxShadowParams.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintBoxShadowParams.h
@@ -11,7 +11,7 @@
 
 namespace Web::Painting {
 
-struct PaintOuterBoxShadowParams {
+struct PaintBoxShadowParams {
     Gfx::Color color;
     ShadowPlacement placement;
     CornerRadii corner_radii;

--- a/Userland/Libraries/LibWeb/Painting/RecordingPainter.cpp
+++ b/Userland/Libraries/LibWeb/Painting/RecordingPainter.cpp
@@ -342,19 +342,15 @@ void RecordingPainter::apply_backdrop_filter(Gfx::IntRect const& backdrop_region
     });
 }
 
-void RecordingPainter::paint_outer_box_shadow_params(PaintOuterBoxShadowParams params)
+void RecordingPainter::paint_outer_box_shadow_params(PaintBoxShadowParams params)
 {
     params.device_content_rect = state().translation.map(params.device_content_rect);
-    append(PaintOuterBoxShadow {
-        .outer_box_shadow_params = params,
-    });
+    append(PaintOuterBoxShadow { .box_shadow_params = params });
 }
 
-void RecordingPainter::paint_inner_box_shadow_params(PaintOuterBoxShadowParams params)
+void RecordingPainter::paint_inner_box_shadow_params(PaintBoxShadowParams params)
 {
-    append(PaintInnerBoxShadow {
-        .outer_box_shadow_params = params,
-    });
+    append(PaintInnerBoxShadow { .box_shadow_params = params });
 }
 
 void RecordingPainter::paint_text_shadow(int blur_radius, Gfx::IntRect bounding_rect, Gfx::IntRect text_rect, Span<Gfx::DrawGlyphOrEmoji const> glyph_run, Color color, int fragment_baseline, Gfx::IntPoint draw_location)

--- a/Userland/Libraries/LibWeb/Painting/RecordingPainter.h
+++ b/Userland/Libraries/LibWeb/Painting/RecordingPainter.h
@@ -34,7 +34,7 @@
 #include <LibWeb/Painting/Command.h>
 #include <LibWeb/Painting/CommandList.h>
 #include <LibWeb/Painting/GradientData.h>
-#include <LibWeb/Painting/PaintOuterBoxShadowParams.h>
+#include <LibWeb/Painting/PaintBoxShadowParams.h>
 
 namespace Web::Painting {
 
@@ -130,8 +130,8 @@ public:
 
     void apply_backdrop_filter(Gfx::IntRect const& backdrop_region, BorderRadiiData const& border_radii_data, CSS::ResolvedBackdropFilter const& backdrop_filter);
 
-    void paint_outer_box_shadow_params(PaintOuterBoxShadowParams params);
-    void paint_inner_box_shadow_params(PaintOuterBoxShadowParams params);
+    void paint_outer_box_shadow_params(PaintBoxShadowParams params);
+    void paint_inner_box_shadow_params(PaintBoxShadowParams params);
     void paint_text_shadow(int blur_radius, Gfx::IntRect bounding_rect, Gfx::IntRect text_rect, Span<Gfx::DrawGlyphOrEmoji const> glyph_run, Color color, int fragment_baseline, Gfx::IntPoint draw_location);
 
     void fill_rect_with_rounded_corners(Gfx::IntRect const& rect, Color color, Gfx::AntiAliasingPainter::CornerRadius top_left_radius, Gfx::AntiAliasingPainter::CornerRadius top_right_radius, Gfx::AntiAliasingPainter::CornerRadius bottom_right_radius, Gfx::AntiAliasingPainter::CornerRadius bottom_left_radius, Vector<Gfx::Path> const& clip_paths = {});

--- a/Userland/Libraries/LibWeb/Painting/ShadowPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ShadowPainting.cpp
@@ -15,14 +15,14 @@
 #include <LibWeb/Layout/Node.h>
 #include <LibWeb/Painting/BorderPainting.h>
 #include <LibWeb/Painting/BorderRadiusCornerClipper.h>
+#include <LibWeb/Painting/PaintBoxShadowParams.h>
 #include <LibWeb/Painting/PaintContext.h>
-#include <LibWeb/Painting/PaintOuterBoxShadowParams.h>
 #include <LibWeb/Painting/PaintableBox.h>
 #include <LibWeb/Painting/ShadowPainting.h>
 
 namespace Web::Painting {
 
-void paint_inner_box_shadow(Gfx::Painter& painter, PaintOuterBoxShadowParams params)
+void paint_inner_box_shadow(Gfx::Painter& painter, PaintBoxShadowParams params)
 {
     auto device_content_rect = params.device_content_rect;
 
@@ -112,7 +112,7 @@ struct OuterBoxShadowMetrics {
     CornerRadius bottom_left_shadow_corner;
 };
 
-static OuterBoxShadowMetrics get_outer_box_shadow_configuration(PaintOuterBoxShadowParams params)
+static OuterBoxShadowMetrics get_outer_box_shadow_configuration(PaintBoxShadowParams params)
 {
     auto device_content_rect = params.device_content_rect;
 
@@ -288,7 +288,7 @@ static OuterBoxShadowMetrics get_outer_box_shadow_configuration(PaintOuterBoxSha
     };
 }
 
-Gfx::IntRect get_outer_box_shadow_bounding_rect(PaintOuterBoxShadowParams params)
+Gfx::IntRect get_outer_box_shadow_bounding_rect(PaintBoxShadowParams params)
 {
     auto shadow_config = get_outer_box_shadow_configuration(params);
 
@@ -305,7 +305,7 @@ Gfx::IntRect get_outer_box_shadow_bounding_rect(PaintOuterBoxShadowParams params
     };
 }
 
-void paint_outer_box_shadow(Gfx::Painter& painter, PaintOuterBoxShadowParams params)
+void paint_outer_box_shadow(Gfx::Painter& painter, PaintBoxShadowParams params)
 {
     auto const& device_content_rect = params.device_content_rect;
 
@@ -550,7 +550,7 @@ void paint_box_shadow(PaintContext& context,
             device_content_rect = context.rounded_device_rect(bordered_content_rect);
         }
 
-        auto params = PaintOuterBoxShadowParams {
+        auto params = PaintBoxShadowParams {
             .color = box_shadow_data.color,
             .placement = box_shadow_data.placement,
             .corner_radii = CornerRadii {

--- a/Userland/Libraries/LibWeb/Painting/ShadowPainting.h
+++ b/Userland/Libraries/LibWeb/Painting/ShadowPainting.h
@@ -8,17 +8,17 @@
 
 #include <LibGfx/Color.h>
 #include <LibWeb/Forward.h>
+#include <LibWeb/Painting/PaintBoxShadowParams.h>
 #include <LibWeb/Painting/PaintContext.h>
-#include <LibWeb/Painting/PaintOuterBoxShadowParams.h>
 #include <LibWeb/Painting/PaintableFragment.h>
 #include <LibWeb/Painting/ShadowData.h>
 
 namespace Web::Painting {
 
-void paint_inner_box_shadow(Gfx::Painter&, PaintOuterBoxShadowParams params);
+void paint_inner_box_shadow(Gfx::Painter&, PaintBoxShadowParams params);
 
-Gfx::IntRect get_outer_box_shadow_bounding_rect(PaintOuterBoxShadowParams params);
-void paint_outer_box_shadow(Gfx::Painter& painter, PaintOuterBoxShadowParams params);
+Gfx::IntRect get_outer_box_shadow_bounding_rect(PaintBoxShadowParams params);
+void paint_outer_box_shadow(Gfx::Painter& painter, PaintBoxShadowParams params);
 
 void paint_box_shadow(
     PaintContext&,


### PR DESCRIPTION
Before this change we were painting inner shadows lying outside of viewport.

Improves painting performance on Github and Twitter where this command is used a lot.