### PR TITLE
Ladybird: Use fontconfig to choose generic fonts on non-Apple systems

### DIFF
--- a/Ladybird/WebContent/CMakeLists.txt
+++ b/Ladybird/WebContent/CMakeLists.txt
@@ -1,4 +1,6 @@
 include(accelerated_graphics)
+include(fontconfig)
+
 set(WEBCONTENT_SOURCE_DIR ${LADYBIRD_SOURCE_DIR}/Userland/Services/WebContent/)
 
 set(WEBCONTENT_SOURCES
@@ -68,6 +70,10 @@ if (ENABLE_QT)
     endif()
 else()
     add_executable(WebContent main.cpp)
+endif()
+
+if (HAS_FONTCONFIG)
+    target_link_libraries(webcontent PRIVATE Fontconfig::Fontconfig)
 endif()
 
 target_link_libraries(WebContent PRIVATE webcontent LibURL)

--- a/Ladybird/WebWorker/CMakeLists.txt
+++ b/Ladybird/WebWorker/CMakeLists.txt
@@ -1,3 +1,5 @@
+include(fontconfig)
+
 set(WEBWORKER_SOURCE_DIR ${LADYBIRD_SOURCE_DIR}/Userland/Services/WebWorker)
 
 set(CMAKE_AUTOMOC OFF)
@@ -21,6 +23,10 @@ target_include_directories(webworker PRIVATE ${LADYBIRD_SOURCE_DIR}/Userland/Ser
 target_include_directories(webworker PRIVATE ${LADYBIRD_SOURCE_DIR}/Userland/)
 target_include_directories(webworker PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/..)
 target_link_libraries(webworker PUBLIC LibCore LibFileSystem LibGfx LibIPC LibJS LibProtocol LibWeb LibWebView LibLocale LibImageDecoderClient LibMain LibURL)
+
+if (HAS_FONTCONFIG)
+    target_link_libraries(webworker PRIVATE Fontconfig::Fontconfig)
+endif()
 
 add_executable(WebWorker main.cpp)
 target_include_directories(WebWorker PRIVATE ${LADYBIRD_SOURCE_DIR}/Userland/)

--- a/Meta/CMake/fontconfig.cmake
+++ b/Meta/CMake/fontconfig.cmake
@@ -1,0 +1,5 @@
+if (NOT APPLE)
+    find_package(Fontconfig REQUIRED)
+    set(HAS_FONTCONFIG ON CACHE BOOL "" FORCE)
+    add_compile_definitions(USE_FONTCONFIG=1)
+endif()

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,7 +2,11 @@
   "builtin-baseline": "01f602195983451bc83e72f4214af2cbc495aa94",
   "dependencies": [
     "sqlite3",
-    "woff2"
+    "woff2",
+    {
+      "name": "fontconfig",
+      "platform": "linux | freebsd | openbsd"
+    }
   ],
   "overrides": [
     {
@@ -12,6 +16,10 @@
     {
       "name": "woff2",
       "version": "1.0.2#4"
+    },
+    {
+      "name": "fontconfig",
+      "version": "2.14.2#1"
     }
   ]
 }


### PR DESCRIPTION
If we get a suggestion from fontconfig, we try those fonts first, before falling back on the hard coded list of known suitable fonts for each generic family.