### PR TITLE
LibWeb: Do not release_value twice parsing a referrer policy

### DIFF
--- a/Userland/Libraries/LibWeb/ReferrerPolicy/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/ReferrerPolicy/AbstractOperations.cpp
@@ -30,7 +30,7 @@ ReferrerPolicy parse_a_referrer_policy_from_a_referrer_policy_header(Fetch::Infr
     // 3. For each token in policy-tokens, if token is a referrer policy and token is not the empty string, then set policy to token.
     for (auto token : policy_tokens) {
         auto referrer_policy = from_string(token);
-        if (referrer_policy.has_value() && referrer_policy.release_value() != ReferrerPolicy::EmptyString)
+        if (referrer_policy.has_value() && referrer_policy.value() != ReferrerPolicy::EmptyString)
             policy = referrer_policy.release_value();
     }
 


### PR DESCRIPTION
This fixes a bug introduced in ab6b687d4c which was causing many live sites (such as chat.openai.com and github.com/serenityos/serenity) to crash.